### PR TITLE
Reset checklist progress when templates change and restrict order actions

### DIFF
--- a/app/Http/Controllers/SolicitudesClienteController.php
+++ b/app/Http/Controllers/SolicitudesClienteController.php
@@ -88,7 +88,18 @@ class SolicitudesClienteController extends Controller
             $data['tipo_servicio'] = $p->nombre;
         }
 
+        $oldPlantilla = $solicitud->plantilla_id;
+        $oldEstado    = $solicitud->estado;
+
         $solicitud->update($data);
+
+        $plantillaCambio = (int) $oldPlantilla !== (int) $solicitud->plantilla_id;
+        $estadoReiniciado = $data['estado'] === Solicitud::PENDIENTE && $oldEstado !== Solicitud::PENDIENTE;
+
+        if ($plantillaCambio || $estadoReiniciado) {
+            $solicitud->pasos()->delete();
+            $solicitud->syncPasosFromPlantilla();
+        }
 
         return back()->with('ok', 'Solicitud actualizada.');
     }

--- a/app/Models/Solicitud.php
+++ b/app/Models/Solicitud.php
@@ -86,10 +86,13 @@ class Solicitud extends Model
         if (!$this->plantilla_id) return;
 
         $ids = PlantillaPaso::where('plantilla_id', $this->plantilla_id)
-            ->orderBy('orden')
+            ->orderBy('numero')
             ->pluck('id');
 
-        if ($ids->isEmpty()) return;
+        if ($ids->isEmpty()) {
+            SolicitudPaso::where('solicitud_id', $this->id)->delete();
+            return;
+        }
 
         foreach ($ids as $pid) {
             SolicitudPaso::firstOrCreate([

--- a/resources/views/ordenes/index.blade.php
+++ b/resources/views/ordenes/index.blade.php
@@ -93,10 +93,12 @@
                             </a>
 
                             {{-- Editar (lleva a /solicitudes con filtro por serie/ID si usas modal) --}}
-                            <a href="{{ route('solicitudes.index', ['q'=>$s->no_serie, 'open'=>$s->id]) }}"
-                               class="rounded-lg border border-gray-300 px-3 py-1.5 hover:bg-gray-100">
-                                Editar
-                            </a>
+                            @if($estado==='pendiente')
+                                <a href="{{ route('solicitudes.index', ['q'=>$s->no_serie, 'open'=>$s->id]) }}"
+                                   class="rounded-lg border border-gray-300 px-3 py-1.5 hover:bg-gray-100">
+                                    Editar
+                                </a>
+                            @endif
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Restablecer el progreso del checklist de la solicitud cuando cambie la plantilla o cuando la orden regrese a estado “pendiente”.

Limitar las actualizaciones del checklist y la finalización manual al usuario asignado; los admins quedan solo lectura en órdenes que no les pertenecen.

Actualizar la UI del checklist para reflejar las nuevas restricciones y ocultar el acceso rápido de “editar” fuera del listado de pendientes.