### PR TITLE
Generate PDF tickets for finalized orders and add client phone

### DIFF
--- a/app/Http/Controllers/ClientesAsignacionController.php
+++ b/app/Http/Controllers/ClientesAsignacionController.php
@@ -18,6 +18,7 @@ class ClientesAsignacionController extends Controller
                 'nombre_empresa',
                 'direccion',
                 'responsable',
+                'telefono',
                 'rfc',
                 'imagen',
                 'correo_empresa',
@@ -27,7 +28,8 @@ class ClientesAsignacionController extends Controller
                     $sq->where('rfc', 'like', "%$q%")
                        ->orWhere('nombre_cliente', 'like', "%$q%")
                        ->orWhere('nombre_empresa', 'like', "%$q%")
-                       ->orWhere('correo_empresa', 'like', "%$q%");
+                       ->orWhere('correo_empresa', 'like', "%$q%")
+                       ->orWhere('telefono', 'like', "%$q%");
                 });
             })
             ->orderBy('nombre_cliente')

--- a/app/Http/Controllers/ClientesCrudController.php
+++ b/app/Http/Controllers/ClientesCrudController.php
@@ -17,7 +17,8 @@ class ClientesCrudController extends Controller
                     $sq->where('rfc', 'like', "%$q%")
                        ->orWhere('nombre_cliente', 'like', "%$q%")
                        ->orWhere('nombre_empresa', 'like', "%$q%")
-                       ->orWhere('correo_empresa', 'like', "%$q%");
+                       ->orWhere('correo_empresa', 'like', "%$q%")
+                       ->orWhere('telefono', 'like', "%$q%");
                 });
             })
             ->orderBy('nombre_cliente')
@@ -68,6 +69,7 @@ class ClientesCrudController extends Controller
             'nombre_empresa'  => ['nullable','string','max:150'],
             'direccion'       => ['nullable','string','max:255'],
             'responsable'     => ['nullable','string','max:150'],
+            'telefono'        => ['nullable','string','max:30'],
             'rfc'             => ['nullable','string','max:50'],
             'imagen'          => ['nullable','string','max:255'],   // usa ruta/url; si quieres upload lo agregamos luego
             'correo_empresa'  => ['nullable','email','max:150'],

--- a/app/Models/ClientesAsignacion.php
+++ b/app/Models/ClientesAsignacion.php
@@ -13,6 +13,7 @@ class ClientesAsignacion extends Model
         'nombre_empresa',
         'direccion',
         'responsable',
+        'telefono',
         'rfc',
         'imagen',
         'correo_empresa',

--- a/app/Models/Solicitud.php
+++ b/app/Models/Solicitud.php
@@ -23,6 +23,7 @@ class Solicitud extends Model
         'tipo_servicio',
         'estado',              // pendiente | en_proceso | finalizado
         'descripcion',
+        'ticket_pdf_path',
         'fecha_vencimiento',   // nullable
     ];
 

--- a/app/Services/TicketPdfGenerator.php
+++ b/app/Services/TicketPdfGenerator.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Solicitud;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Support\Facades\Storage;
+
+class TicketPdfGenerator
+{
+    public function generate(Solicitud $solicitud): string
+    {
+        $solicitud->loadMissing([
+            'cliente',
+            'asignado',
+            'plantilla',
+            'pasos.paso',
+        ]);
+
+        $existing = $solicitud->ticket_pdf_path;
+        if ($existing && Storage::disk('local')->exists($existing)) {
+            Storage::disk('local')->delete($existing);
+        }
+
+        [$primaryColor, $secondaryColor] = $this->paletteForTemplate($solicitud->plantilla?->id);
+
+        $pdf = Pdf::loadView('ordenes.ticket', [
+            'solicitud'      => $solicitud,
+            'primaryColor'   => $primaryColor,
+            'secondaryColor' => $secondaryColor,
+            'generatedAt'    => now(),
+        ])->setPaper('letter', 'portrait');
+
+        $path = sprintf('tickets/solicitud-%d-%s.pdf',
+            $solicitud->id,
+            now()->format('YmdHis')
+        );
+
+        Storage::disk('local')->put($path, $pdf->output());
+
+        return $path;
+    }
+
+    private function paletteForTemplate(?int $templateId): array
+    {
+        if (!$templateId) {
+            return ['#1f2937', '#4b5563'];
+        }
+
+        $hash = crc32((string) $templateId);
+        $hue = $hash % 360;
+
+        $primary = $this->hslToHex($hue, 65, 38);
+        $secondary = $this->hslToHex(($hue + 25) % 360, 55, 52);
+
+        return [$primary, $secondary];
+    }
+
+    private function hslToHex(int $h, int $s, int $l): string
+    {
+        $h /= 360;
+        $s /= 100;
+        $l /= 100;
+
+        if ($s == 0) {
+            $r = $g = $b = $l;
+        } else {
+            $q = $l < 0.5 ? $l * (1 + $s) : $l + $s - $l * $s;
+            $p = 2 * $l - $q;
+            $r = $this->hueToRgb($p, $q, $h + 1 / 3);
+            $g = $this->hueToRgb($p, $q, $h);
+            $b = $this->hueToRgb($p, $q, $h - 1 / 3);
+        }
+
+        return sprintf('#%02x%02x%02x',
+            (int) round($r * 255),
+            (int) round($g * 255),
+            (int) round($b * 255)
+        );
+    }
+
+    private function hueToRgb(float $p, float $q, float $t): float
+    {
+        if ($t < 0) {
+            $t += 1;
+        }
+        if ($t > 1) {
+            $t -= 1;
+        }
+        if ($t < 1 / 6) {
+            return $p + ($q - $p) * 6 * $t;
+        }
+        if ($t < 1 / 2) {
+            return $q;
+        }
+        if ($t < 2 / 3) {
+            return $p + ($q - $p) * (2 / 3 - $t) * 6;
+        }
+        return $p;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "barryvdh/laravel-dompdf": "^3.1",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "spatie/laravel-permission": "^6.21"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,85 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2d426ee66f1b0dfb52e6c4471556b86",
+    "content-hash": "dfb0ca4f65a8e9e6d0043617178593e4",
     "packages": [
+        {
+            "name": "barryvdh/laravel-dompdf",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-dompdf.git",
+                "reference": "8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d",
+                "reference": "8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/dompdf": "^3.0",
+                "illuminate/support": "^9|^10|^11|^12",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.7|^3.0",
+                "orchestra/testbench": "^7|^8|^9|^10",
+                "phpro/grumphp": "^2.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf",
+                        "Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf"
+                    },
+                    "providers": [
+                        "Barryvdh\\DomPDF\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\DomPDF\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "A DOMPDF Wrapper for Laravel",
+            "keywords": [
+                "dompdf",
+                "laravel",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-dompdf/issues",
+                "source": "https://github.com/barryvdh/laravel-dompdf/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-13T15:07:54+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.0",
@@ -376,6 +453,161 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "db712c90c5b9868df3600e64e68da62e78a34623"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/db712c90c5b9868df3600e64e68da62e78a34623",
+                "reference": "db712c90c5b9868df3600e64e68da62e78a34623",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.4"
+            },
+            "time": "2025-10-29T12:43:30+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.1"
+            },
+            "time": "2024-12-02T14:37:59+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.0"
+            },
+            "time": "2024-04-29T13:26:35+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -2010,6 +2242,73 @@
             "time": "2024-12-08T08:18:47+00:00"
         },
         {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.9.0",
             "source": {
@@ -3275,6 +3574,72 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.1"
             },
             "time": "2025-09-04T20:59:21+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v8.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^5.6.20 || ^7.0.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41",
+                "rawr/cross-data-providers": "^2.0.0"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.9.0"
+            },
+            "time": "2025-07-11T13:20:48+00:00"
         },
         {
             "name": "spatie/laravel-permission",

--- a/database/migrations/2025_11_03_224454_add_telefono_to_clientes_asignaciones_table.php
+++ b/database/migrations/2025_11_03_224454_add_telefono_to_clientes_asignaciones_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clientes_asignaciones', function (Blueprint $table) {
+            $table->string('telefono', 30)
+                ->nullable()
+                ->after('responsable');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clientes_asignaciones', function (Blueprint $table) {
+            $table->dropColumn('telefono');
+        });
+    }
+};

--- a/database/migrations/2025_11_03_224505_add_ticket_pdf_path_to_solicitudes_table.php
+++ b/database/migrations/2025_11_03_224505_add_ticket_pdf_path_to_solicitudes_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('solicitudes', function (Blueprint $table) {
+            $table->string('ticket_pdf_path', 255)
+                ->nullable()
+                ->after('descripcion');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('solicitudes', function (Blueprint $table) {
+            $table->dropColumn('ticket_pdf_path');
+        });
+    }
+};

--- a/resources/views/clientes/index.blade.php
+++ b/resources/views/clientes/index.blade.php
@@ -60,7 +60,7 @@
             <span class="icon">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
             </span>
-            <input id="searchClientes" type="text" placeholder="Buscar por RFC, nombre, empresa o correo…"
+            <input id="searchClientes" type="text" placeholder="Buscar por RFC, nombre, empresa, correo o teléfono…"
                    class="w-full focus:outline-none focus:ring-2 focus:ring-indigo-500">
             @if(!empty($q))
               <a class="clear" href="{{ route('clientes.index') }}">Limpiar</a>
@@ -77,6 +77,7 @@
                         <th class="text-left">Empresa</th>
                         <th class="text-left">Dirección</th>
                         <th class="text-left">Responsable</th>
+                        <th class="text-left">Teléfono</th>
                         <th class="text-left">RFC</th>
                         <th class="text-left">Correo empresa</th>
                         <th class="text-right">Acciones</th>
@@ -111,6 +112,7 @@
                         <td>{{ $c->nombre_empresa }}</td>
                         <td>{{ $c->direccion }}</td>
                         <td>{{ $c->responsable }}</td>
+                        <td>{{ $c->telefono ?? '—' }}</td>
                         <td class="uppercase tracking-wide">{{ $c->rfc }}</td>
                         <td>{{ $c->correo_empresa }}</td>
                         <td>
@@ -131,7 +133,7 @@
                         </td>
                     </tr>
                 @empty
-                    <tr><td colspan="8" class="px-4 py-8 text-center text-gray-500">Sin registros.</td></tr>
+                    <tr><td colspan="9" class="px-4 py-8 text-center text-gray-500">Sin registros.</td></tr>
                 @endforelse
                 </tbody>
             </table>
@@ -192,6 +194,11 @@
                                class="mt-1 w-full rounded-xl border-gray-300">
                     </div>
                     <div>
+                        <label class="text-sm text-gray-700">Teléfono</label>
+                        <input name="telefono" x-model="form.telefono"
+                               class="mt-1 w-full rounded-xl border-gray-300">
+                    </div>
+                    <div>
                         <label class="text-sm text-gray-700">Correo de la empresa</label>
                         <input type="email" name="correo_empresa" x-model="form.correo_empresa"
                                class="mt-1 w-full rounded-xl border-gray-300">
@@ -224,11 +231,11 @@
         return {
             modalOpen:false,
             mode:'create',
-            form:{ id:null,nombre_cliente:'',nombre_empresa:'',direccion:'',responsable:'',rfc:'',imagen:'',correo_empresa:'' },
-            openCreate(){ this.mode='create'; this.form={ id:null,nombre_cliente:'',nombre_empresa:'',direccion:'',responsable:'',rfc:'',imagen:'',correo_empresa:'' }; this.modalOpen=true; },
+            form:{ id:null,nombre_cliente:'',nombre_empresa:'',direccion:'',responsable:'',telefono:'',rfc:'',imagen:'',correo_empresa:'' },
+            openCreate(){ this.mode='create'; this.form={ id:null,nombre_cliente:'',nombre_empresa:'',direccion:'',responsable:'',telefono:'',rfc:'',imagen:'',correo_empresa:'' }; this.modalOpen=true; },
             openEdit(item){
                 this.mode='edit';
-                this.form={ id:item.id,nombre_cliente:item.nombre_cliente ?? '',nombre_empresa:item.nombre_empresa ?? '',direccion:item.direccion ?? '',responsable:item.responsable ?? '',rfc:item.rfc ?? '',imagen:item.imagen ?? '',correo_empresa:item.correo_empresa ?? '' };
+                this.form={ id:item.id,nombre_cliente:item.nombre_cliente ?? '',nombre_empresa:item.nombre_empresa ?? '',direccion:item.direccion ?? '',responsable:item.responsable ?? '',telefono:item.telefono ?? '',rfc:item.rfc ?? '',imagen:item.imagen ?? '',correo_empresa:item.correo_empresa ?? '' };
                 this.modalOpen=true;
             },
             close(){ this.modalOpen=false; },
@@ -261,8 +268,8 @@
             paginate: { previous: '<', next: '>' }
           },
           columnDefs: [
-            { targets:[0,7], className:'align-middle' },
-            { targets:[1,2,3,4,5,6], className:'align-middle' }
+            { targets:[0,8], className:'align-middle' },
+            { targets:[1,2,3,4,5,6,7], className:'align-middle' }
           ]
         });
 

--- a/resources/views/clientes/seleccion.blade.php
+++ b/resources/views/clientes/seleccion.blade.php
@@ -8,7 +8,7 @@
                     type="text"
                     name="q"
                     value="{{ $q ?? '' }}"
-                    placeholder="Buscar por RFC, nombre, empresa o correo…"
+                    placeholder="Buscar por RFC, nombre, empresa, correo o teléfono…"
                     class="w-full rounded-xl border border-gray-300 bg-white pl-11 pr-4 py-2.5
                            focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500" />
             </div>
@@ -33,6 +33,7 @@
                             <div class="truncate font-medium text-gray-900">{{ $c->nombre_cliente }}</div>
                             <div class="truncate text-xs text-gray-500">{{ $c->nombre_empresa }}</div>
                             <div class="truncate text-xs text-gray-400">{{ $c->correo_empresa }}</div>
+                            <div class="truncate text-xs text-gray-400">{{ $c->telefono }}</div>
                         </div>
 
                         <a href="{{ route('clientes.equipos-solicitudes', $c->id) }}"

--- a/resources/views/ordenes/checklist.blade.php
+++ b/resources/views/ordenes/checklist.blade.php
@@ -21,6 +21,13 @@
             </h1>
 
             <div class="flex gap-2">
+                @if($solicitud->estado === \App\Models\Solicitud::FINALIZADO)
+                    <a href="{{ route('ordenes.ticket', $solicitud) }}"
+                       class="rounded-xl border border-emerald-300 text-emerald-700 px-4 py-2 hover:bg-emerald-50"
+                       target="_blank">
+                        Ticket PDF
+                    </a>
+                @endif
                 <a href="{{ url('/ordenes/en_proceso') }}"
                    class="rounded-xl border px-4 py-2 bg-white text-gray-700 hover:bg-gray-50">Volver</a>
 

--- a/resources/views/ordenes/index.blade.php
+++ b/resources/views/ordenes/index.blade.php
@@ -122,6 +122,14 @@
                                 }}
                             </a>
 
+                            @if($s->estado === 'finalizado')
+                                <a href="{{ route('ordenes.ticket', $s) }}"
+                                   class="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 hover:bg-emerald-50"
+                                   target="_blank">
+                                    Ticket PDF
+                                </a>
+                            @endif
+
                             {{-- Editar (solo cuando está pendiente) --}}
                             @if($estado==='pendiente')
                                 <a href="{{ route('solicitudes.index', ['q'=>$s->no_serie, 'open'=>$s->id]) }}"

--- a/resources/views/ordenes/ticket.blade.php
+++ b/resources/views/ordenes/ticket.blade.php
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Ticket orden #{{ $solicitud->id }}</title>
+    <style>
+        * { box-sizing: border-box; font-family: 'DejaVu Sans', sans-serif; }
+        body { margin: 0; padding: 24px; background: #f7f7f7; color: #1f2933; }
+        .card { background: #ffffff; border-radius: 16px; padding: 28px; box-shadow: 0 8px 24px rgba(31,41,55,0.12); }
+        .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 24px; }
+        .badge { padding: 6px 12px; border-radius: 999px; font-size: 12px; font-weight: 600; color: #fff; text-transform: uppercase; letter-spacing: 0.05em; }
+        h1 { margin: 0; font-size: 26px; color: {{ $primaryColor }}; }
+        .meta { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; margin-bottom: 24px; }
+        .meta .item { border: 1px solid #e5e7eb; border-radius: 12px; padding: 12px 16px; background: rgba(148,163,184,0.08); }
+        .meta .label { font-size: 11px; text-transform: uppercase; color: #64748b; letter-spacing: 0.08em; margin-bottom: 4px; }
+        .meta .value { font-size: 15px; color: #111827; font-weight: 600; }
+        .section-title { font-size: 15px; font-weight: 700; color: {{ $primaryColor }}; margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.08em; }
+        .steps { border: 1px solid rgba(148,163,184,0.35); border-radius: 14px; padding: 16px; }
+        .steps table { width: 100%; border-collapse: collapse; }
+        .steps th, .steps td { text-align: left; padding: 10px; font-size: 13px; }
+        .steps tr:nth-child(odd) { background: rgba(241,245,249,0.6); }
+        .footer { margin-top: 28px; display: flex; justify-content: space-between; align-items: flex-end; font-size: 12px; color: #64748b; }
+        .stamp { display: inline-flex; flex-direction: column; align-items: flex-start; border: 2px dashed {{ $secondaryColor }}; padding: 10px 14px; border-radius: 12px; }
+        .stamp strong { color: {{ $secondaryColor }}; font-size: 14px; text-transform: uppercase; letter-spacing: 0.06em; }
+        .tagline { margin-top: 6px; font-size: 11px; color: #94a3b8; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="header">
+            <div>
+                <h1>Orden de servicio #{{ $solicitud->id }}</h1>
+                <div class="tagline">Plantilla: {{ $solicitud->plantilla->nombre ?? 'No definida' }}</div>
+            </div>
+            <div class="badge" style="background: {{ $primaryColor }};">Finalizado</div>
+        </div>
+
+        <div class="meta">
+            <div class="item">
+                <div class="label">Cliente</div>
+                <div class="value">{{ $solicitud->cliente->nombre_cliente ?? '—' }}</div>
+            </div>
+            <div class="item">
+                <div class="label">Asignado a</div>
+                <div class="value">{{ $solicitud->asignado->name ?? '—' }}</div>
+            </div>
+            <div class="item">
+                <div class="label">No. de serie</div>
+                <div class="value">{{ $solicitud->no_serie ?? '—' }}</div>
+            </div>
+            <div class="item">
+                <div class="label">Dispositivo</div>
+                <div class="value">{{ trim($solicitud->dispositivo.' '.$solicitud->modelo) }}</div>
+            </div>
+            <div class="item">
+                <div class="label">Tipo de servicio</div>
+                <div class="value">{{ $solicitud->tipo_servicio }}</div>
+            </div>
+            <div class="item">
+                <div class="label">Cliente teléfono</div>
+                <div class="value">{{ $solicitud->cliente->telefono ?? '—' }}</div>
+            </div>
+        </div>
+
+        <div class="section-title">Resumen de la plantilla</div>
+        <div class="steps">
+            <table>
+                <thead>
+                    <tr>
+                        <th style="width: 40px;">#</th>
+                        <th>Descripción del paso</th>
+                        <th style="width: 120px;">Estado</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($solicitud->plantilla->pasos ?? [] as $paso)
+                        @php($registro = $solicitud->pasos->firstWhere('plantilla_paso_id', $paso->id))
+                        <tr>
+                            <td>{{ $paso->numero }}</td>
+                            <td>
+                                <div>{{ $paso->titulo }}</div>
+                                @if(!empty($registro?->notas))
+                                    <div style="font-size: 11px; color: #64748b; margin-top: 4px;">Nota: {{ $registro->notas }}</div>
+                                @endif
+                            </td>
+                            <td>{{ $registro && $registro->hecho ? 'Completado' : 'Pendiente' }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        <div class="footer">
+            <div>
+                <div>Generado el {{ $generatedAt->format('d/m/Y H:i') }}</div>
+                <div>Documento generado automáticamente al finalizar el checklist.</div>
+            </div>
+            <div class="stamp">
+                <strong>Servicio completado</strong>
+                <span>Responsable: {{ $solicitud->asignado->name ?? '—' }}</span>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/solicitudes/index.blade.php
+++ b/resources/views/solicitudes/index.blade.php
@@ -178,6 +178,14 @@
                                     @endif
                                 @endif
 
+                                @if($s->estado === 'finalizado')
+                                    <a href="{{ route('ordenes.ticket', $s) }}"
+                                       class="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 hover:bg-emerald-50"
+                                       target="_blank">
+                                        Ticket
+                                    </a>
+                                @endif
+
                                 <form method="POST" action="{{ route('solicitudes.destroy', $s) }}"
                                       onsubmit="return confirm('¿Eliminar esta solicitud?')">
                                     @csrf @method('DELETE')

--- a/routes/web.php
+++ b/routes/web.php
@@ -105,6 +105,9 @@ Route::middleware(['auth','role:admin|virtuality'])->group(function () {
     // Finalizar manualmente (opcional)
     Route::post('/ordenes/{solicitud}/finalizar', [OrdenesServicioController::class,'finalizar'])
         ->name('ordenes.finalizar');
+
+    Route::get('/ordenes/{solicitud}/ticket', [OrdenesServicioController::class,'ticket'])
+        ->name('ordenes.ticket');
 });
 
 // Solo admin


### PR DESCRIPTION
Se instaló barryvdh/laravel-dompdf y se añadió un servicio TicketPdfGenerator para que, al finalizar una solicitud, se genere y almacene un PDF de ticket específico de la plantilla; los controladores regeneran el archivo cuando es necesario.

Se agregó una plantilla Blade para PDF, además de una nueva ruta y botones, de modo que las órdenes resueltas muestren descargas de “Ticket PDF” desde los listados, el checklist y las pantallas de solicitudes.

Se capturaron los números de teléfono del cliente mediante migraciones, validación, filtros y actualizaciones de la UI, tanto en la tabla de gestión como en el diálogo de selección.