### PR TITLE
Add public ticket endpoint for shareable links

### DIFF
--- a/app/Http/Controllers/OrdenesServicioController.php
+++ b/app/Http/Controllers/OrdenesServicioController.php
@@ -184,6 +184,17 @@ class OrdenesServicioController extends Controller
     {
         $user = Auth::user();
         abort_unless($user->hasRole('admin') || $solicitud->asignado_a === $user->id, 403);
+
+        return $this->downloadTicket($solicitud);
+    }
+
+    public function publicTicket(Solicitud $solicitud)
+    {
+        return $this->downloadTicket($solicitud);
+    }
+
+    private function downloadTicket(Solicitud $solicitud)
+    {
         abort_unless($solicitud->estado === Solicitud::FINALIZADO, 404);
 
         if (!$solicitud->ticket_pdf_path || !Storage::disk('local')->exists($solicitud->ticket_pdf_path)) {

--- a/resources/views/ordenes/checklist.blade.php
+++ b/resources/views/ordenes/checklist.blade.php
@@ -22,7 +22,7 @@
 
             <div class="flex gap-2">
                 @if($solicitud->estado === \App\Models\Solicitud::FINALIZADO)
-                    <a href="{{ route('ordenes.ticket', $solicitud) }}"
+                    <a href="{{ route('ticket.public', $solicitud) }}"
                        class="rounded-xl border border-emerald-300 text-emerald-700 px-4 py-2 hover:bg-emerald-50"
                        target="_blank">
                         Ticket PDF

--- a/resources/views/ordenes/index.blade.php
+++ b/resources/views/ordenes/index.blade.php
@@ -123,7 +123,7 @@
                             </a>
 
                             @if($s->estado === 'finalizado')
-                                <a href="{{ route('ordenes.ticket', $s) }}"
+                                <a href="{{ route('ticket.public', $s) }}"
                                    class="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 hover:bg-emerald-50"
                                    target="_blank">
                                     Ticket PDF

--- a/resources/views/solicitudes/index.blade.php
+++ b/resources/views/solicitudes/index.blade.php
@@ -179,7 +179,7 @@
                                 @endif
 
                                 @if($s->estado === 'finalizado')
-                                    <a href="{{ route('ordenes.ticket', $s) }}"
+                                    <a href="{{ route('ticket.public', $s) }}"
                                        class="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 hover:bg-emerald-50"
                                        target="_blank">
                                         Ticket

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,10 @@ Route::get('/dashboard', DashboardController::class)
     ->middleware(['auth','verified'])
     ->name('dashboard');
 
+Route::get('/ticket/{solicitud}', [OrdenesServicioController::class, 'publicTicket'])
+    ->whereNumber('solicitud')
+    ->name('ticket.public');
+
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
## Summary
- add a public `/ticket/{solicitud}` route that downloads the ticket PDF for finalised orders
- reuse the ticket generation logic and update UI links to the new shareable route

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913f0582148832691ee47dd483223ad)