### PR TITLE
Add WhatsApp ticket tracking and resend option

### DIFF
--- a/app/Http/Controllers/WhatsappController.php
+++ b/app/Http/Controllers/WhatsappController.php
@@ -17,7 +17,7 @@ class WhatsappController extends Controller
      */
     public function enviarPorSolicitud(Solicitud $solicitud): JsonResponse
     {
-        $result = $this->whatsapp->sendTicketTemplate($solicitud);
+        $result = $this->whatsapp->sendTicketTemplateWithTracking($solicitud);
 
         return response()->json($result);
     }

--- a/database/migrations/2025_11_04_000000_add_whatsapp_fields_to_solicitudes_table.php
+++ b/database/migrations/2025_11_04_000000_add_whatsapp_fields_to_solicitudes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('solicitudes', function (Blueprint $table) {
+            $table->string('whatsapp_ticket_status', 30)->nullable()->after('ticket_pdf_path');
+            $table->timestamp('whatsapp_ticket_sent_at')->nullable()->after('whatsapp_ticket_status');
+            $table->text('whatsapp_ticket_error')->nullable()->after('whatsapp_ticket_sent_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('solicitudes', function (Blueprint $table) {
+            $table->dropColumn([
+                'whatsapp_ticket_status',
+                'whatsapp_ticket_sent_at',
+                'whatsapp_ticket_error',
+            ]);
+        });
+    }
+};

--- a/resources/views/ordenes/index.blade.php
+++ b/resources/views/ordenes/index.blade.php
@@ -87,6 +87,31 @@
                                 {{ $s->pasos_hechos_count ?? 0 }}/{{ $s->total_pasos ?? 0 }}
                             </div>
 
+                            @if($s->estado === 'finalizado')
+                                @php
+                                    $whatsStatus = $s->whatsapp_ticket_status;
+                                    $whatsBadge = 'bg-gray-100 text-gray-800';
+                                    $whatsText = 'No enviado todavía';
+
+                                    if($whatsStatus === 'sent') {
+                                        $whatsBadge = 'bg-emerald-100 text-emerald-800';
+                                        $whatsText = 'Enviado ' . ($s->whatsapp_ticket_sent_at?->diffForHumans() ?? '');
+                                    } elseif($whatsStatus) {
+                                        $whatsBadge = 'bg-amber-100 text-amber-800';
+                                        $whatsText = 'Con errores ' . ($s->whatsapp_ticket_sent_at?->diffForHumans() ?? '');
+                                    }
+                                @endphp
+                                <div class="sm:col-span-2 flex items-center gap-2">
+                                    <span class="text-gray-500">• WhatsApp:</span>
+                                    <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $whatsBadge }}">
+                                        {{ $whatsText }}
+                                    </span>
+                                    @if($whatsStatus === 'sent' && $s->whatsapp_ticket_expired)
+                                        <span class="text-xs text-gray-500">(expira en 1 hora)</span>
+                                    @endif
+                                </div>
+                            @endif
+
                             {{-- (Opcional) Badge de vencimiento --}}
                             @php
                                 $fv = $s->fecha_vencimiento;
@@ -136,6 +161,16 @@
                                    class="rounded-lg border border-gray-300 px-3 py-1.5 hover:bg-gray-100">
                                     Editar
                                 </a>
+                            @endif
+
+                            @if($s->should_resend_whatsapp_ticket)
+                                <form action="{{ route('ordenes.reenviar_whatsapp', $s) }}" method="POST">
+                                    @csrf
+                                    <button type="submit"
+                                            class="rounded-lg border border-indigo-200 bg-indigo-50 text-indigo-700 px-3 py-1.5 hover:bg-indigo-100">
+                                        Volver a enviar
+                                    </button>
+                                </form>
                             @endif
                         </div>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -114,6 +114,10 @@ Route::middleware(['auth','role:admin|virtuality'])->group(function () {
     Route::post('/ordenes/{solicitud}/finalizar', [OrdenesServicioController::class,'finalizar'])
         ->name('ordenes.finalizar');
 
+    // Reenviar mensaje de ticket por WhatsApp
+    Route::post('/ordenes/{solicitud}/reenviar-whatsapp', [OrdenesServicioController::class,'reenviarWhatsapp'])
+        ->name('ordenes.reenviar_whatsapp');
+
     Route::get('/ordenes/{solicitud}/ticket', [OrdenesServicioController::class,'ticket'])
         ->name('ordenes.ticket');
 });


### PR DESCRIPTION
Se agregaron campos de seguimiento en la base de datos y helpers en el modelo para registrar los envíos de tickets por WhatsApp, las verificaciones de vencimiento y la elegibilidad de reenvío para las solicitudes finalizadas.

Se actualizó el servicio de WhatsApp para usar el parámetro del botón de la plantilla, normalizar los payloads y guardar los resultados de envío (incluidos los errores) para cada solicitud.

Se habilitaron los flujos de reenvío con una ruta protegida, una acción de controlador y un botón en la interfaz que muestra el estado de envío de WhatsApp en las órdenes finalizadas y permite reintentar cuando falle o esté expirado.