### PR TITLE
Standardize hybrid responsive layouts for listings

### DIFF
--- a/resources/views/clientes/index.blade.php
+++ b/resources/views/clientes/index.blade.php
@@ -5,7 +5,7 @@
 
     <div x-data="clientesUI()" class="mx-auto max-w-7xl space-y-6">
         {{-- Header --}}
-        <div class="flex items-center justify-between">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
                 <h1 class="text-2xl font-semibold text-gray-800">Clientes</h1>
                 <p class="text-sm text-gray-500">Gestiona a tus clientes y sus datos de contacto.</p>
@@ -67,8 +67,62 @@
             @endif
         </div>
 
-        {{-- Tabla --}}
-        <div class="overflow-x-auto rounded-2xl border border-gray-200 bg-white shadow-sm">
+        {{-- Cards móvil --}}
+        <div class="md:hidden space-y-4">
+            @forelse ($clientes as $c)
+                @php
+                    $url = $c->imagen
+                        ? (filter_var($c->imagen, FILTER_VALIDATE_URL) ? $c->imagen : asset($c->imagen))
+                        : null;
+                @endphp
+                <div class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+                    <div class="flex items-start gap-3">
+                        @if($url)
+                            <img
+                                src="{{ $url }}"
+                                class="h-10 w-10 rounded-full object-cover ring-1 ring-gray-200"
+                                onerror="this.replaceWith(Object.assign(document.createElement('div'),{
+                                    className:'h-10 w-10 rounded-full ring-1 ring-gray-200 flex items-center justify-center text-[10px] text-gray-500 bg-gray-100',
+                                    innerText:'Sin imagen'
+                                }))"
+                            />
+                        @else
+                            <div class="h-10 w-10 rounded-full ring-1 ring-gray-200 flex items-center justify-center text-[10px] text-gray-500 bg-gray-100">
+                                Sin imagen
+                            </div>
+                        @endif
+                        <div class="flex-1 min-w-0">
+                            <div class="font-semibold text-gray-900 truncate">{{ $c->nombre_cliente }}</div>
+                            <div class="text-sm text-gray-500 truncate">{{ $c->nombre_empresa }}</div>
+                            <div class="text-xs text-gray-400 truncate">{{ $c->correo_empresa }}</div>
+                            <div class="text-xs text-gray-400 truncate">{{ $c->telefono ?? '—' }}</div>
+                        </div>
+                    </div>
+
+                    <div class="mt-3 flex flex-wrap gap-2">
+                        <button @click='openEdit(@json($c))'
+                                class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-100">
+                            Editar
+                        </button>
+                        <form method="POST" action="{{ route('clientes.destroy', $c->id) }}"
+                              onsubmit="return confirm('¿Eliminar este cliente?')">
+                            @csrf @method('DELETE')
+                            <button type="submit"
+                                    class="rounded-lg border border-red-300 text-red-700 px-3 py-1.5 text-sm hover:bg-red-50">
+                                Eliminar
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            @empty
+                <div class="rounded-2xl border border-gray-200 bg-white p-8 text-center text-gray-500">
+                    Sin registros.
+                </div>
+            @endforelse
+        </div>
+
+        {{-- Tabla desktop --}}
+        <div class="hidden md:block overflow-x-auto rounded-2xl border border-gray-200 bg-white shadow-sm">
             <table id="tablaClientes" class="min-w-full text-sm">
                 <thead class="text-gray-600">
                     <tr>

--- a/resources/views/clientes/seleccion.blade.php
+++ b/resources/views/clientes/seleccion.blade.php
@@ -1,6 +1,11 @@
 <x-app-layout>
     <div class="mx-auto max-w-6xl space-y-5">
-        <h1 class="text-xl font-semibold text-gray-800">Selección de solicitud de clientes</h1>
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <h1 class="text-xl font-semibold text-gray-800">Selección de solicitud de clientes</h1>
+                <p class="text-sm text-gray-500">Elige un cliente para gestionar sus equipos y solicitudes.</p>
+            </div>
+        </div>
 
         <form method="GET" action="{{ route('clientes.seleccion') }}">
             <div class="relative">
@@ -9,7 +14,7 @@
                     name="q"
                     value="{{ $q ?? '' }}"
                     placeholder="Buscar por RFC, nombre, empresa, correo o teléfono…"
-                    class="w-full rounded-xl border border-gray-300 bg-white pl-11 pr-4 py-2.5
+                    class="w-full rounded-xl border border-gray-300 bg-white pl-4 pr-4 py-2.5
                            focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500" />
             </div>
         </form>
@@ -19,27 +24,91 @@
                 Seleccionar cliente
             </div>
 
-            <div class="p-4 space-y-3">
-                @forelse ($clientes as $c)
-                    <div class="flex items-center gap-3 rounded-xl bg-gray-100 px-3 py-2.5">
-                        <img
-                            src="{{ $c->imagen ? asset($c->imagen) : asset('img/sin-imagen.png') }}"
-                            alt="Logo de {{ $c->nombre_cliente }}"
-                            class="h-8 w-8 rounded-full object-cover bg-gray-200"
-                            onerror="this.onerror=null;this.src='{{ asset('img/sin-imagen.png') }}';"
-                        />
+            {{-- Tabla desktop --}}
+            <div class="hidden md:block overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead class="bg-gray-50 text-gray-700">
+                        <tr>
+                            <th class="px-4 py-3 text-left font-semibold">Cliente</th>
+                            <th class="px-4 py-3 text-left font-semibold">Identificador</th>
+                            <th class="px-4 py-3 text-left font-semibold">Contacto</th>
+                            <th class="px-4 py-3 text-right font-semibold">Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-100">
+                        @forelse ($clientes as $c)
+                            <tr class="hover:bg-gray-50">
+                                <td class="px-4 py-3">
+                                    <div class="flex items-center gap-3">
+                                        <img
+                                            src="{{ $c->imagen ? asset($c->imagen) : asset('img/sin-imagen.png') }}"
+                                            alt="Logo de {{ $c->nombre_cliente }}"
+                                            class="h-9 w-9 rounded-full object-cover bg-gray-200"
+                                            onerror="this.onerror=null;this.src='{{ asset('img/sin-imagen.png') }}';"
+                                        />
+                                        <div>
+                                            <div class="font-medium text-gray-900">{{ $c->nombre_cliente }}</div>
+                                            <div class="text-xs text-gray-500">{{ $c->nombre_empresa }}</div>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="px-4 py-3 text-gray-700 uppercase">{{ $c->rfc ?? '—' }}</td>
+                                <td class="px-4 py-3 text-gray-700">
+                                    <div class="text-sm">{{ $c->correo_empresa }}</div>
+                                    <div class="text-xs text-gray-500">{{ $c->telefono }}</div>
+                                </td>
+                                <td class="px-4 py-3">
+                                    <div class="flex items-center justify-end gap-2">
+                                        <a href="{{ route('clientes.equipos-solicitudes', $c->id) }}"
+                                           class="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-3 py-1.5 text-sm text-white hover:bg-indigo-700">
+                                            Seleccionar
+                                        </a>
+                                        <a href="{{ route('clientes.equipos-solicitudes', $c->id) }}"
+                                           class="inline-flex items-center justify-center rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100">
+                                            Ver equipos/solicitudes
+                                        </a>
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="4" class="px-4 py-8 text-center text-gray-500">No hay registros en clientes_asignaciones.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
 
-                        <div class="flex-1 min-w-0">
-                            <div class="truncate font-medium text-gray-900">{{ $c->nombre_cliente }}</div>
-                            <div class="truncate text-xs text-gray-500">{{ $c->nombre_empresa }}</div>
-                            <div class="truncate text-xs text-gray-400">{{ $c->correo_empresa }}</div>
-                            <div class="truncate text-xs text-gray-400">{{ $c->telefono }}</div>
+            {{-- Cards móvil --}}
+            <div class="md:hidden p-4 space-y-3">
+                @forelse ($clientes as $c)
+                    <div class="rounded-xl bg-gray-50 px-3 py-3 ring-1 ring-gray-200">
+                        <div class="flex items-center gap-3">
+                            <img
+                                src="{{ $c->imagen ? asset($c->imagen) : asset('img/sin-imagen.png') }}"
+                                alt="Logo de {{ $c->nombre_cliente }}"
+                                class="h-9 w-9 rounded-full object-cover bg-gray-200"
+                                onerror="this.onerror=null;this.src='{{ asset('img/sin-imagen.png') }}';"
+                            />
+
+                            <div class="flex-1 min-w-0">
+                                <div class="truncate font-medium text-gray-900">{{ $c->nombre_cliente }}</div>
+                                <div class="truncate text-xs text-gray-500">{{ $c->nombre_empresa }}</div>
+                                <div class="truncate text-xs text-gray-400">{{ $c->correo_empresa }}</div>
+                                <div class="truncate text-xs text-gray-400">{{ $c->telefono }}</div>
+                            </div>
                         </div>
 
-                        <a href="{{ route('clientes.equipos-solicitudes', $c->id) }}"
-                           class="inline-flex items-center justify-center rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-200">
-                            Ir
-                        </a>
+                        <div class="mt-3 flex flex-wrap gap-2">
+                            <a href="{{ route('clientes.equipos-solicitudes', $c->id) }}"
+                               class="inline-flex items-center justify-center rounded-xl bg-indigo-600 px-3 py-1.5 text-sm text-white hover:bg-indigo-700">
+                                Seleccionar
+                            </a>
+                            <a href="{{ route('clientes.equipos-solicitudes', $c->id) }}"
+                               class="inline-flex items-center justify-center rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100">
+                                Ver equipos/solicitudes
+                            </a>
+                        </div>
                     </div>
                 @empty
                     <div class="rounded-xl bg-white p-6 text-center text-gray-500">

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,13 +1,13 @@
 {{-- resources/views/dashboard.blade.php --}}
 <x-app-layout>
-    <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Dashboard') }}
-        </h2>
-    </x-slot>
-
     <div class="py-8">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h1 class="text-2xl font-semibold text-gray-800">Dashboard</h1>
+                    <p class="text-sm text-gray-500">Monitorea el estado general y accede a los listados clave.</p>
+                </div>
+            </div>
 
             {{-- KPIs --}}
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/resources/views/folios/index.blade.php
+++ b/resources/views/folios/index.blade.php
@@ -41,7 +41,36 @@
                 @endunless
             </div>
 
-            <div class="overflow-x-auto">
+            {{-- Cards móvil --}}
+            <div class="md:hidden divide-y">
+                @forelse($folios as $folio)
+                    <div class="px-4 py-4">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <div class="font-semibold text-gray-900">Folio #{{ $folio->id }}</div>
+                                <div class="text-xs text-gray-500">{{ $folio->dispositivo }} · {{ $folio->modelo ?: '—' }}</div>
+                            </div>
+                            <a href="{{ route('ticket.public', $folio) }}" target="_blank"
+                               class="inline-flex items-center gap-1 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs text-emerald-700 hover:bg-emerald-100">
+                                Ver ticket
+                            </a>
+                        </div>
+                        <div class="mt-2 grid gap-1 text-sm text-gray-700">
+                            <div><span class="text-gray-500">Serie:</span> {{ $folio->no_serie ?: '—' }}</div>
+                            <div><span class="text-gray-500">Cliente:</span> {{ optional($folio->cliente)->nombre_cliente ?? '—' }}</div>
+                            <div><span class="text-gray-500">Reparó:</span> {{ optional($folio->asignado)->name ?? '—' }}</div>
+                            <div><span class="text-gray-500">Solicitado:</span> {{ optional($folio->created_at)->format('Y-m-d') }}</div>
+                            <div><span class="text-gray-500">Reparado:</span> {{ optional($folio->updated_at)->format('Y-m-d') }}</div>
+                            <div class="text-xs text-gray-500">Servicio: {{ $folio->tipo_servicio }}</div>
+                            <div class="text-xs text-gray-500 break-words">{{ $folio->descripcion ?: 'Sin descripción' }}</div>
+                        </div>
+                    </div>
+                @empty
+                    <div class="px-4 py-10 text-center text-gray-500">No hay dispositivos reparados con los filtros seleccionados.</div>
+                @endforelse
+            </div>
+
+            <div class="hidden md:block overflow-x-auto">
                 <table class="min-w-full divide-y divide-gray-200 text-sm">
                     <thead class="bg-gray-50">
                         <tr>

--- a/resources/views/ordenes/checklist.blade.php
+++ b/resources/views/ordenes/checklist.blade.php
@@ -12,37 +12,60 @@
         $doneMap = $solicitud->pasos->keyBy('plantilla_paso_id');
         $pct = $total > 0 ? intval(($hechos / $total) * 100) : 0;
         $puedeGestionar = $puedeGestionar ?? false;
+
+        $estadoColor = [
+            'pendiente' => 'bg-yellow-100 text-yellow-800',
+            'en_proceso' => 'bg-blue-100 text-blue-800',
+            'finalizado' => 'bg-green-100 text-green-800',
+            'vencidas' => 'bg-red-100 text-red-800',
+        ][$solicitud->estado] ?? 'bg-gray-100 text-gray-800';
+
+        $fv = $solicitud->fecha_vencimiento;
+        $venceTxt = $fv ? $fv->format('Y-m-d') : '—';
     @endphp
 
     <div class="mx-auto max-w-5xl space-y-6">
-        <div class="flex items-center justify-between">
-            <h1 class="text-xl font-semibold text-gray-800">
-                Checklist – Orden #{{ $solicitud->id }}
-            </h1>
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div class="space-y-2">
+                <h1 class="text-xl font-semibold text-gray-800">
+                    Checklist – Orden #{{ $solicitud->id }}
+                </h1>
+                <div class="flex flex-wrap items-center gap-2 text-sm text-gray-600">
+                    <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $estadoColor }}">
+                        {{ Str::of($solicitud->estado)->replace('_',' ')->ucfirst() }}
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700">
+                        Vence: {{ $venceTxt }}
+                    </span>
+                    <span class="inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-700">
+                        Progreso: {{ $hechos }} / {{ $total }}
+                    </span>
+                </div>
+            </div>
 
-            <div class="flex gap-2">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
                 @if($solicitud->estado === \App\Models\Solicitud::FINALIZADO)
                     <a href="{{ route('ticket.public', $solicitud) }}"
-                       class="rounded-xl border border-emerald-300 text-emerald-700 px-4 py-2 hover:bg-emerald-50"
+                       class="rounded-xl border border-emerald-300 text-emerald-700 px-4 py-2 text-sm hover:bg-emerald-50"
                        target="_blank">
                         Ticket PDF
                     </a>
                 @endif
                 <a href="{{ url('/ordenes/en_proceso') }}"
-                   class="rounded-xl border px-4 py-2 bg-white text-gray-700 hover:bg-gray-50">Volver</a>
+                   class="rounded-xl border px-4 py-2 text-sm bg-white text-gray-700 hover:bg-gray-50">Volver</a>
 
                 @if($puedeGestionar)
                     <form method="POST" action="{{ route('ordenes.finalizar', $solicitud) }}">
                         @csrf
                         <button
-                            class="rounded-xl px-4 py-2 {{ $total>0 && $hechos >= $total ? 'bg-emerald-600 text-white hover:bg-emerald-700' : 'bg-gray-300 text-gray-600 cursor-not-allowed' }}"
+                            class="rounded-xl px-4 py-2 text-sm {{ $total>0 && $hechos >= $total ? 'bg-emerald-600 text-white hover:bg-emerald-700' : 'bg-gray-300 text-gray-600 cursor-not-allowed' }}"
                             {{ $total>0 && $hechos >= $total ? '' : 'disabled' }}>
                             Finalizar
                         </button>
                     </form>
                 @else
                     <button
-                        class="rounded-xl px-4 py-2 bg-gray-300 text-gray-600 cursor-not-allowed"
+                        class="rounded-xl px-4 py-2 text-sm bg-gray-300 text-gray-600 cursor-not-allowed"
                         disabled>
                         Finalizar
                     </button>
@@ -57,7 +80,7 @@
         @endunless
 
         {{-- Tarjeta de info --}}
-        <div class="rounded-2xl border bg-white p-4 grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <div class="rounded-2xl border bg-white p-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
                 <div class="text-sm text-gray-500">Cliente</div>
                 <div class="font-medium">{{ $solicitud->cliente->nombre_cliente ?? '—' }}</div>
@@ -99,35 +122,35 @@
                         $sp = $doneMap->get($pp->id);
                         $estaHecho = (bool) ($sp->hecho ?? false);
                     @endphp
-                    <li class="px-4 py-3 flex items-start gap-3">
+                    <li class="px-4 py-4">
                         @if($puedeGestionar)
                             <form method="POST"
                                   action="{{ route('ordenes.toggle', ['solicitud'=>$solicitud->id, 'paso'=>$pp->id]) }}"
-                                  class="flex items-start gap-3 w-full">
+                                  class="flex flex-col gap-3 sm:flex-row sm:items-start">
                                 @csrf
                                 @method('PATCH')
 
                                 <button type="submit"
-                                    class="mt-0.5 h-5 w-5 rounded border flex items-center justify-center
+                                    class="mt-0.5 h-6 w-6 sm:h-5 sm:w-5 rounded border flex items-center justify-center
                                            {{ $estaHecho ? 'bg-indigo-600 border-indigo-600 text-white' : 'bg-white border-gray-300 text-transparent' }}">
                                     ✓
                                 </button>
 
-                                <div class="flex-1">
-                                    <div class="font-medium">
+                                <div class="flex-1 space-y-2">
+                                    <div class="font-medium text-gray-900">
                                         {{ $pp->numero }}. {{ $pp->titulo }}
                                         @if($estaHecho)
                                             <span class="ml-2 text-xs rounded bg-emerald-100 text-emerald-700 px-2 py-0.5">hecho</span>
                                         @endif
                                     </div>
                                     @if(!empty($sp?->notas))
-                                        <div class="text-sm text-gray-600 mt-1">
+                                        <div class="text-sm text-gray-600">
                                             <span class="font-medium">Notas:</span> {{ $sp->notas }}
                                         </div>
                                     @endif
 
                                     {{-- Campo opcional para agregar/actualizar notas al marcar --}}
-                                    <div class="mt-2">
+                                    <div>
                                         <input type="text" name="notas" placeholder="Agregar nota (opcional)"
                                                class="w-full rounded-lg border px-3 py-2 text-sm"
                                                value="{{ old('notas') }}">
@@ -135,26 +158,26 @@
                                 </div>
                             </form>
                         @else
-                            <div class="flex items-start gap-3 w-full opacity-70">
-                                <span class="mt-0.5 h-5 w-5 rounded border flex items-center justify-center
+                            <div class="flex flex-col gap-3 sm:flex-row sm:items-start opacity-70">
+                                <span class="mt-0.5 h-6 w-6 sm:h-5 sm:w-5 rounded border flex items-center justify-center
                                              {{ $estaHecho ? 'bg-indigo-600 border-indigo-600 text-white' : 'bg-white border-gray-300 text-transparent' }}">
                                     ✓
                                 </span>
 
-                                <div class="flex-1">
-                                    <div class="font-medium">
+                                <div class="flex-1 space-y-2">
+                                    <div class="font-medium text-gray-900">
                                         {{ $pp->numero }}. {{ $pp->titulo }}
                                         @if($estaHecho)
                                             <span class="ml-2 text-xs rounded bg-emerald-100 text-emerald-700 px-2 py-0.5">hecho</span>
                                         @endif
                                     </div>
                                     @if(!empty($sp?->notas))
-                                        <div class="text-sm text-gray-600 mt-1">
+                                        <div class="text-sm text-gray-600">
                                             <span class="font-medium">Notas:</span> {{ $sp->notas }}
                                         </div>
                                     @endif
 
-                                    <div class="mt-2 text-xs text-gray-500">
+                                    <div class="text-xs text-gray-500">
                                         Solo la persona asignada puede actualizar este paso.
                                     </div>
                                 </div>

--- a/resources/views/ordenes/index.blade.php
+++ b/resources/views/ordenes/index.blade.php
@@ -6,10 +6,13 @@
     <div class="mx-auto max-w-7xl space-y-6">
 
         {{-- Header + tabs --}}
-        <div class="flex items-center justify-between">
-            <h1 class="text-2xl font-semibold text-gray-800">Órdenes de servicio / {{ $titulo }}</h1>
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold text-gray-800">Órdenes de servicio / {{ $titulo }}</h1>
+                <p class="text-sm text-gray-500">Gestiona órdenes por estado y accede a sus acciones clave.</p>
+            </div>
 
-            <div class="flex gap-2">
+            <div class="flex flex-wrap gap-2">
                 <a href="{{ route('ordenes.pendientes') }}"
                    class="px-3 py-1.5 rounded-lg border text-sm {{ $estado==='pendiente' ? 'bg-gray-900 text-white border-gray-900' : 'bg-white border-gray-300 hover:bg-gray-50' }}">
                     Pendientes
@@ -65,60 +68,41 @@
             </div>
         </form>
 
-        {{-- Lista tipo “cards” --}}
+        {{-- Listado híbrido --}}
         <div class="rounded-2xl border border-gray-200 bg-white shadow-sm">
             <div class="px-4 py-3 border-b bg-gray-900 text-white rounded-t-2xl">
                 • {{ $titulo }}
             </div>
 
-            @forelse($solicitudes as $s)
-                <div class="px-4 py-3 border-b last:border-b-0">
-                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                        <div class="grid sm:grid-cols-2 gap-x-10 gap-y-1 text-sm text-gray-800">
-                            <div>• <span class="text-gray-500">Dispositivo:</span> {{ $s->dispositivo }}</div>
-                            <div>• <span class="text-gray-500">Empleado asignado:</span> {{ optional($s->asignado)->name ?? '—' }}</div>
-
-                            <div>• <span class="text-gray-500">Cliente:</span> {{ optional($s->cliente)->nombre_cliente ?? '—' }}</div>
-                            <div>• <span class="text-gray-500">ID equipo:</span> {{ $s->no_serie ?: '—' }}</div>
-
-                            <div>• <span class="text-gray-500">Tipo de servicio:</span> {{ $s->tipo_servicio }}</div>
-                            <div>
-                                • <span class="text-gray-500">Pasos hechos:</span>
-                                {{ $s->pasos_hechos_count ?? 0 }}/{{ $s->total_pasos ?? 0 }}
-                            </div>
-
-                            @if($s->estado === 'finalizado')
-                                @php
-                                    $whatsStatus = $s->whatsapp_ticket_status;
-                                    $whatsBadge = 'bg-gray-100 text-gray-800';
-                                    $whatsText = 'No enviado todavía';
-
-                                    if($whatsStatus === 'sent') {
-                                        $whatsBadge = 'bg-emerald-100 text-emerald-800';
-                                        $whatsText = 'Enviado ' . ($s->whatsapp_ticket_sent_at?->diffForHumans() ?? '');
-                                    } elseif($whatsStatus) {
-                                        $whatsBadge = 'bg-amber-100 text-amber-800';
-                                        $whatsText = 'Con errores ' . ($s->whatsapp_ticket_sent_at?->diffForHumans() ?? '');
-                                    }
-                                @endphp
-                                <div class="sm:col-span-2 flex items-center gap-2">
-                                    <span class="text-gray-500">• WhatsApp:</span>
-                                    <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $whatsBadge }}">
-                                        {{ $whatsText }}
-                                    </span>
-                                    @if($whatsStatus === 'sent' && $s->whatsapp_ticket_expired)
-                                        <span class="text-xs text-gray-500">(expira en 1 hora)</span>
-                                    @endif
-                                </div>
-                            @endif
-
-                            {{-- (Opcional) Badge de vencimiento --}}
+            {{-- Tabla desktop --}}
+            <div class="hidden md:block overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 text-sm">
+                    <thead class="bg-gray-50 text-gray-700">
+                        <tr>
+                            <th class="px-4 py-3 text-left font-semibold">Folio</th>
+                            <th class="px-4 py-3 text-left font-semibold">Cliente</th>
+                            <th class="px-4 py-3 text-left font-semibold">Dispositivo / Modelo / Serie</th>
+                            <th class="px-4 py-3 text-left font-semibold">Tipo de servicio</th>
+                            <th class="px-4 py-3 text-left font-semibold">Asignado a</th>
+                            <th class="px-4 py-3 text-left font-semibold">Vence</th>
+                            <th class="px-4 py-3 text-left font-semibold">Estado</th>
+                            <th class="px-4 py-3 text-right font-semibold">Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-100 text-gray-700">
+                        @forelse($solicitudes as $s)
                             @php
+                                $estadoColor = [
+                                    'pendiente' => 'bg-yellow-100 text-yellow-800',
+                                    'en_proceso' => 'bg-blue-100 text-blue-800',
+                                    'finalizado' => 'bg-green-100 text-green-800',
+                                    'vencidas' => 'bg-red-100 text-red-800',
+                                ][$s->estado] ?? 'bg-gray-100 text-gray-800';
+
                                 $fv = $s->fecha_vencimiento;
-                                $venceTxt = '—';
+                                $venceTxt = $fv ? $fv->format('Y-m-d') : '—';
                                 $venceBadge = 'bg-gray-100 text-gray-700';
                                 if($fv){
-                                    $venceTxt = $fv->format('Y-m-d');
                                     if($s->estado!=='finalizado'){
                                         if($fv->isBefore(today())) $venceBadge='bg-red-100 text-red-800';
                                         elseif($fv->isSameDay(today())) $venceBadge='bg-amber-100 text-amber-800';
@@ -128,18 +112,121 @@
                                     }
                                 }
                             @endphp
-                            <div class="sm:col-span-2">
-                                • <span class="text-gray-500">Vence:</span>
-                                <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $venceBadge }}">
-                                    {{ $venceTxt }}
+                            <tr class="hover:bg-gray-50">
+                                <td class="px-4 py-3 font-medium text-gray-900">#{{ $s->id }}</td>
+                                <td class="px-4 py-3">{{ optional($s->cliente)->nombre_cliente ?? '—' }}</td>
+                                <td class="px-4 py-3">
+                                    <div class="font-medium text-gray-900">{{ $s->dispositivo }}</div>
+                                    <div class="text-xs text-gray-500">Modelo: {{ $s->modelo ?: '—' }}</div>
+                                    <div class="text-xs text-gray-500">Serie: {{ $s->no_serie ?: '—' }}</div>
+                                </td>
+                                <td class="px-4 py-3">{{ $s->tipo_servicio }}</td>
+                                <td class="px-4 py-3">{{ optional($s->asignado)->name ?? '—' }}</td>
+                                <td class="px-4 py-3">
+                                    <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $venceBadge }}">
+                                        {{ $venceTxt }}
+                                    </span>
+                                </td>
+                                <td class="px-4 py-3">
+                                    <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $estadoColor }}">
+                                        {{ Str::of($s->estado)->replace('_',' ')->ucfirst() }}
+                                    </span>
+                                </td>
+                                <td class="px-4 py-3">
+                                    <div class="flex items-center justify-end gap-2">
+                                        <a href="{{ route('ordenes.checklist', $s) }}"
+                                           class="rounded-lg bg-gray-900 text-white px-3 py-1.5 hover:bg-black">
+                                            {{
+                                                $estado==='pendiente'   ? 'Resolver'  :
+                                                ($estado==='en_proceso' ? 'Continuar' :
+                                                ($estado==='vencidas'   ? 'Atender'   : 'Ver'))
+                                            }}
+                                        </a>
+
+                                        @if($s->estado === 'finalizado')
+                                            <a href="{{ route('ticket.public', $s) }}"
+                                               class="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 hover:bg-emerald-50"
+                                               target="_blank">
+                                                Ticket PDF
+                                            </a>
+                                        @endif
+
+                                        @if($estado==='pendiente')
+                                            <a href="{{ route('solicitudes.index', ['q'=>$s->no_serie, 'open'=>$s->id]) }}"
+                                               class="rounded-lg border border-gray-300 px-3 py-1.5 hover:bg-gray-100">
+                                                Editar
+                                            </a>
+                                        @endif
+
+                                        @if($s->should_resend_whatsapp_ticket)
+                                            <form action="{{ route('ordenes.reenviar_whatsapp', $s) }}" method="POST">
+                                                @csrf
+                                                <button type="submit"
+                                                        class="rounded-lg border border-indigo-200 bg-indigo-50 text-indigo-700 px-3 py-1.5 hover:bg-indigo-100">
+                                                    Volver a enviar
+                                                </button>
+                                            </form>
+                                        @endif
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="8" class="px-4 py-10 text-center text-gray-500">No hay órdenes en este estado.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            {{-- Cards móvil --}}
+            <div class="md:hidden divide-y">
+                @forelse($solicitudes as $s)
+                    @php
+                        $estadoColor = [
+                            'pendiente' => 'bg-yellow-100 text-yellow-800',
+                            'en_proceso' => 'bg-blue-100 text-blue-800',
+                            'finalizado' => 'bg-green-100 text-green-800',
+                            'vencidas' => 'bg-red-100 text-red-800',
+                        ][$s->estado] ?? 'bg-gray-100 text-gray-800';
+
+                        $fv = $s->fecha_vencimiento;
+                        $venceTxt = $fv ? $fv->format('Y-m-d') : '—';
+                        $venceBadge = 'bg-gray-100 text-gray-700';
+                        if($fv){
+                            if($s->estado!=='finalizado'){
+                                if($fv->isBefore(today())) $venceBadge='bg-red-100 text-red-800';
+                                elseif($fv->isSameDay(today())) $venceBadge='bg-amber-100 text-amber-800';
+                                else $venceBadge='bg-sky-100 text-sky-800';
+                            } else {
+                                $venceBadge='bg-gray-100 text-gray-600';
+                            }
+                        }
+                    @endphp
+                    <div class="px-4 py-4">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <div class="font-semibold text-gray-900">Orden #{{ $s->id }}</div>
+                                <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $estadoColor }}">
+                                    {{ Str::of($s->estado)->replace('_',' ')->ucfirst() }}
                                 </span>
                             </div>
+                            <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $venceBadge }}">
+                                {{ $venceTxt }}
+                            </span>
                         </div>
 
-                        <div class="flex items-center gap-2">
-                            {{-- Resolver/Continuar → checklist --}}
+                        <div class="mt-3 grid gap-1 text-sm text-gray-700">
+                            <div><span class="text-gray-500">Cliente:</span> {{ optional($s->cliente)->nombre_cliente ?? '—' }}</div>
+                            <div><span class="text-gray-500">Dispositivo:</span> {{ $s->dispositivo }} · {{ $s->modelo ?: '—' }}</div>
+                            <div><span class="text-gray-500">Serie:</span> {{ $s->no_serie ?: '—' }}</div>
+                            <div><span class="text-gray-500">Servicio:</span> {{ $s->tipo_servicio }}</div>
+                            <div><span class="text-gray-500">Asignado:</span> {{ optional($s->asignado)->name ?? '—' }}</div>
+                        </div>
+
+                        <div class="mt-3 flex flex-wrap gap-2">
                             <a href="{{ route('ordenes.checklist', $s) }}"
-                               class="rounded-lg bg-gray-900 text-white px-3 py-1.5 hover:bg-black">
+                               class="rounded-lg bg-gray-900 text-white px-3 py-1.5 text-sm hover:bg-black">
                                 {{
                                     $estado==='pendiente'   ? 'Resolver'  :
                                     ($estado==='en_proceso' ? 'Continuar' :
@@ -149,16 +236,15 @@
 
                             @if($s->estado === 'finalizado')
                                 <a href="{{ route('ticket.public', $s) }}"
-                                   class="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 hover:bg-emerald-50"
+                                   class="rounded-lg border border-emerald-300 text-emerald-700 px-3 py-1.5 text-sm hover:bg-emerald-50"
                                    target="_blank">
                                     Ticket PDF
                                 </a>
                             @endif
 
-                            {{-- Editar (solo cuando está pendiente) --}}
                             @if($estado==='pendiente')
                                 <a href="{{ route('solicitudes.index', ['q'=>$s->no_serie, 'open'=>$s->id]) }}"
-                                   class="rounded-lg border border-gray-300 px-3 py-1.5 hover:bg-gray-100">
+                                   class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-100">
                                     Editar
                                 </a>
                             @endif
@@ -167,17 +253,17 @@
                                 <form action="{{ route('ordenes.reenviar_whatsapp', $s) }}" method="POST">
                                     @csrf
                                     <button type="submit"
-                                            class="rounded-lg border border-indigo-200 bg-indigo-50 text-indigo-700 px-3 py-1.5 hover:bg-indigo-100">
+                                            class="rounded-lg border border-indigo-200 bg-indigo-50 text-indigo-700 px-3 py-1.5 text-sm hover:bg-indigo-100">
                                         Volver a enviar
                                     </button>
                                 </form>
                             @endif
                         </div>
                     </div>
-                </div>
-            @empty
-                <div class="px-4 py-12 text-center text-gray-500">No hay órdenes en este estado.</div>
-            @endforelse
+                @empty
+                    <div class="px-4 py-12 text-center text-gray-500">No hay órdenes en este estado.</div>
+                @endforelse
+            </div>
 
             <div class="px-4 py-3">
                 {{ $solicitudes->links() }}

--- a/resources/views/plantillas/index.blade.php
+++ b/resources/views/plantillas/index.blade.php
@@ -6,7 +6,7 @@
   <div x-data="{ modal:false, mode:'create', form:{id:null,nombre:'',descripcion:''} }"
        class="mx-auto max-w-7xl space-y-6">
 
-    <div class="flex items-center justify-between">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <h1 class="text-2xl font-semibold text-gray-800">Plantillas de servicios</h1>
         <p class="text-sm text-gray-500">Crea plantillas (ej. “Cambio de memoria”) y gestiona sus pasos.</p>
@@ -26,22 +26,65 @@
     {{-- lista --}}
     <div class="rounded-2xl border border-gray-200 bg-white shadow-sm">
       <div class="rounded-t-2xl bg-[#1f262b] px-4 py-2 text-center text-sm font-medium text-gray-100">Plantillas</div>
-      <div class="p-4 space-y-3">
+
+      {{-- Tabla desktop --}}
+      <div class="hidden md:block overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-gray-50 text-gray-700">
+            <tr>
+              <th class="px-4 py-3 text-left font-semibold">Nombre</th>
+              <th class="px-4 py-3 text-left font-semibold">Descripción</th>
+              <th class="px-4 py-3 text-left font-semibold"># pasos</th>
+              <th class="px-4 py-3 text-right font-semibold">Acciones</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            @forelse($plantillas as $p)
+              <tr class="hover:bg-gray-50">
+                <td class="px-4 py-3 font-medium text-gray-900">{{ $p->nombre }}</td>
+                <td class="px-4 py-3 text-gray-700">{{ $p->descripcion }}</td>
+                <td class="px-4 py-3 text-gray-700">{{ $p->pasos_count ?? $p->pasos?->count() ?? 0 }}</td>
+                <td class="px-4 py-3">
+                  <div class="flex items-center justify-end gap-2">
+                    <a href="{{ route('plantillas.pasos', $p) }}"
+                       class="rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-100">Ver pasos</a>
+                    <button @click="mode='edit';form={id:{{ $p->id }},nombre:@js($p->nombre),descripcion:@js($p->descripcion)};modal=true"
+                            class="rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-100">Editar</button>
+                    <form method="POST" action="{{ route('plantillas.destroy',$p) }}"
+                          onsubmit="return confirm('¿Eliminar esta plantilla y sus pasos?')">
+                      @csrf @method('DELETE')
+                      <button class="rounded-xl border border-red-300 text-red-700 px-3 py-1.5 text-sm hover:bg-red-50">Borrar</button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+            @empty
+              <tr>
+                <td colspan="4" class="px-4 py-8 text-center text-gray-500">No hay plantillas aún.</td>
+              </tr>
+            @endforelse
+          </tbody>
+        </table>
+      </div>
+
+      {{-- Cards móvil --}}
+      <div class="md:hidden p-4 space-y-3">
         @forelse($plantillas as $p)
-          <div class="flex items-center gap-3 rounded-xl bg-gray-50 px-4 py-3 ring-1 ring-gray-200">
-            <div class="flex-1">
-              <div class="font-medium text-gray-900">{{ $p->nombre }}</div>
-              <div class="text-sm text-gray-500">{{ $p->descripcion }}</div>
+          <div class="rounded-xl bg-gray-50 px-4 py-3 ring-1 ring-gray-200">
+            <div class="font-medium text-gray-900">{{ $p->nombre }}</div>
+            <div class="text-sm text-gray-500">{{ $p->descripcion }}</div>
+            <div class="mt-1 text-xs text-gray-400">{{ $p->pasos_count ?? $p->pasos?->count() ?? 0 }} pasos</div>
+            <div class="mt-3 flex flex-wrap gap-2">
+              <a href="{{ route('plantillas.pasos', $p) }}"
+                 class="rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-100">Ver pasos</a>
+              <button @click="mode='edit';form={id:{{ $p->id }},nombre:@js($p->nombre),descripcion:@js($p->descripcion)};modal=true"
+                      class="rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-100">Editar</button>
+              <form method="POST" action="{{ route('plantillas.destroy',$p) }}"
+                    onsubmit="return confirm('¿Eliminar esta plantilla y sus pasos?')">
+                @csrf @method('DELETE')
+                <button class="rounded-xl border border-red-300 text-red-700 px-3 py-1.5 text-sm hover:bg-red-50">Borrar</button>
+              </form>
             </div>
-            <a href="{{ route('plantillas.pasos', $p) }}"
-               class="rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-100">Ir</a>
-            <button @click="mode='edit';form={id:{{ $p->id }},nombre:@js($p->nombre),descripcion:@js($p->descripcion)};modal=true"
-                    class="rounded-xl border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-100">Editar</button>
-            <form method="POST" action="{{ route('plantillas.destroy',$p) }}"
-                  onsubmit="return confirm('¿Eliminar esta plantilla y sus pasos?')">
-              @csrf @method('DELETE')
-              <button class="rounded-xl border border-red-300 text-red-700 px-3 py-1.5 text-sm hover:bg-red-50">Borrar</button>
-            </form>
           </div>
         @empty
           <div class="p-6 text-center text-gray-500">No hay plantillas aún.</div>

--- a/resources/views/plantillas/pasos.blade.php
+++ b/resources/views/plantillas/pasos.blade.php
@@ -10,7 +10,7 @@
       }"
       class="mx-auto max-w-7xl space-y-6">
 
-    <div class="flex items-center justify-between">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <h1 class="text-2xl font-semibold text-gray-800">{{ $plantilla->nombre }}</h1>
         <p class="text-sm text-gray-500">Máximo 15 pasos por plantilla.</p>
@@ -23,7 +23,7 @@
 
     {{-- agregar paso --}}
     <div class="rounded-2xl border border-gray-200 bg-white shadow-sm p-4">
-      <form method="POST" action="{{ route('plantillas.pasos.store',$plantilla) }}" class="flex items-center gap-3">
+      <form method="POST" action="{{ route('plantillas.pasos.store',$plantilla) }}" class="flex flex-col gap-3 sm:flex-row sm:items-center">
         @csrf
         <input name="titulo" placeholder="Nuevo paso (ej. Verificar si hay material disponible)"
                class="flex-1 rounded-xl border border-gray-300 px-3 py-2" required>
@@ -44,35 +44,87 @@
         Pasos ({{ $plantilla->pasos->count() }})
       </div>
 
-      <div class="p-4 space-y-3">
+      {{-- Tabla desktop --}}
+      <div class="hidden md:block overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-gray-50 text-gray-700">
+            <tr>
+              <th class="px-4 py-3 text-left font-semibold">Orden</th>
+              <th class="px-4 py-3 text-left font-semibold">Paso</th>
+              <th class="px-4 py-3 text-right font-semibold">Acciones</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            @forelse($plantilla->pasos as $paso)
+              <tr class="hover:bg-gray-50">
+                <td class="px-4 py-3">
+                  <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gray-900 text-white text-sm font-semibold">
+                    {{ $paso->numero }}
+                  </span>
+                </td>
+                <td class="px-4 py-3 text-gray-800">{{ $paso->titulo }}</td>
+                <td class="px-4 py-3">
+                  <div class="flex items-center justify-end gap-2">
+                    <form method="POST" action="{{ route('plantillas.pasos.mover', [$plantilla,$paso]) }}">
+                      @csrf
+                      <input type="hidden" name="dir" value="up">
+                      <button class="rounded-lg border px-2 py-1 text-sm hover:bg-gray-100" {{ $paso->numero==1 ? 'disabled' : '' }}>↑</button>
+                    </form>
+                    <form method="POST" action="{{ route('plantillas.pasos.mover', [$plantilla,$paso]) }}">
+                      @csrf
+                      <input type="hidden" name="dir" value="down">
+                      <button class="rounded-lg border px-2 py-1 text-sm hover:bg-gray-100"
+                              {{ $paso->numero==$plantilla->pasos->max('numero') ? 'disabled' : '' }}>↓</button>
+                    </form>
+                    <button @click="openEdit(@js(['id'=>$paso->id,'titulo'=>$paso->titulo]))"
+                            class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-100">Editar</button>
+                    <form method="POST" action="{{ route('plantillas.pasos.destroy', [$plantilla,$paso]) }}"
+                          onsubmit="return confirm('¿Eliminar este paso?')">
+                      @csrf @method('DELETE')
+                      <button class="rounded-lg border border-red-300 text-red-700 px-3 py-1.5 text-sm hover:bg-red-50">Borrar</button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+            @empty
+              <tr>
+                <td colspan="3" class="px-4 py-8 text-center text-gray-500">Aún no hay pasos para esta plantilla.</td>
+              </tr>
+            @endforelse
+          </tbody>
+        </table>
+      </div>
+
+      {{-- Cards móvil --}}
+      <div class="md:hidden p-4 space-y-3">
         @forelse($plantilla->pasos as $paso)
-          <div class="flex items-center gap-3 rounded-xl bg-gray-50 px-4 py-3 ring-1 ring-gray-200">
-            <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gray-900 text-white text-sm font-semibold">
-              {{ $paso->numero }}
-            </span>
-            <div class="flex-1">{{ $paso->titulo }}</div>
-
-            {{-- mover --}}
-            <form method="POST" action="{{ route('plantillas.pasos.mover', [$plantilla,$paso]) }}">
-              @csrf
-              <input type="hidden" name="dir" value="up">
-              <button class="rounded-lg border px-2 py-1 text-sm hover:bg-gray-100" {{ $paso->numero==1 ? 'disabled' : '' }}>↑</button>
-            </form>
-            <form method="POST" action="{{ route('plantillas.pasos.mover', [$plantilla,$paso]) }}">
-              @csrf
-              <input type="hidden" name="dir" value="down">
-              <button class="rounded-lg border px-2 py-1 text-sm hover:bg-gray-100"
-                      {{ $paso->numero==$plantilla->pasos->max('numero') ? 'disabled' : '' }}>↓</button>
-            </form>
-
-            {{-- editar / borrar --}}
-            <button @click="openEdit(@js(['id'=>$paso->id,'titulo'=>$paso->titulo]))"
-                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-100">Editar</button>
-            <form method="POST" action="{{ route('plantillas.pasos.destroy', [$plantilla,$paso]) }}"
-                  onsubmit="return confirm('¿Eliminar este paso?')">
-              @csrf @method('DELETE')
-              <button class="rounded-lg border border-red-300 text-red-700 px-3 py-1.5 text-sm hover:bg-red-50">Borrar</button>
-            </form>
+          <div class="rounded-xl bg-gray-50 px-4 py-3 ring-1 ring-gray-200">
+            <div class="flex items-start gap-3">
+              <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-900 text-white text-sm font-semibold">
+                {{ $paso->numero }}
+              </span>
+              <div class="flex-1 text-gray-800">{{ $paso->titulo }}</div>
+            </div>
+            <div class="mt-3 flex flex-wrap gap-2">
+              <form method="POST" action="{{ route('plantillas.pasos.mover', [$plantilla,$paso]) }}">
+                @csrf
+                <input type="hidden" name="dir" value="up">
+                <button class="rounded-lg border px-2 py-1 text-sm hover:bg-gray-100" {{ $paso->numero==1 ? 'disabled' : '' }}>↑</button>
+              </form>
+              <form method="POST" action="{{ route('plantillas.pasos.mover', [$plantilla,$paso]) }}">
+                @csrf
+                <input type="hidden" name="dir" value="down">
+                <button class="rounded-lg border px-2 py-1 text-sm hover:bg-gray-100"
+                        {{ $paso->numero==$plantilla->pasos->max('numero') ? 'disabled' : '' }}>↓</button>
+              </form>
+              <button @click="openEdit(@js(['id'=>$paso->id,'titulo'=>$paso->titulo]))"
+                      class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm hover:bg-gray-100">Editar</button>
+              <form method="POST" action="{{ route('plantillas.pasos.destroy', [$plantilla,$paso]) }}"
+                    onsubmit="return confirm('¿Eliminar este paso?')">
+                @csrf @method('DELETE')
+                <button class="rounded-lg border border-red-300 text-red-700 px-3 py-1.5 text-sm hover:bg-red-50">Borrar</button>
+              </form>
+            </div>
           </div>
         @empty
           <div class="p-6 text-center text-gray-500">Aún no hay pasos para esta plantilla.</div>


### PR DESCRIPTION

Unificar la apariencia y el comportamiento de las páginas tipo listado para que en escritorio se muestren tablas y en móvil se muestren cards apiladas en toda la aplicación.

Asegurar patrones consistentes de contenedor/encabezado/filtros/acciones para /dashboard, /ordenes/*, /clientes*, /plantillas*, /folios y las vistas relacionadas de checklist.

Mejorar la usabilidad en móvil para que las acciones y la información clave sigan disponibles y legibles, sin perder funcionalidad en escritorio.



Convertir varias vistas de listados a un diseño híbrido: tablas en desktop (md en adelante) y cards en móvil (< md), con acciones y badges equivalentes (archivos actualizados en resources/views/*).

Actualizar ordenes y solicitudes para usar una tabla en desktop con acciones por fila y un layout de cards en móvil con botones de acción equivalentes y badges de estado/vencimiento.

Ajustar la vista checklist para exponer metadatos de la orden (estado, vence, progreso) y hacer que los pasos sean más amigables al tacto y se apilen mejor en móvil, manteniendo las acciones del formulario en escritorio.

Aplicar el mismo patrón responsivo a clientes (index y selección), plantillas (index y pasos) y folios, con encabezados consistentes, texto de ayuda y marcado responsivo.