### PR TITLE
Queued WhatsApp notification for Pendiente→En_proceso (idempotent, tracked)

### DIFF
--- a/app/Http/Controllers/OrdenesServicioController.php
+++ b/app/Http/Controllers/OrdenesServicioController.php
@@ -102,6 +102,7 @@ class OrdenesServicioController extends Controller
 
         if ($puedeGestionar && $solicitud->estado === Solicitud::PENDIENTE) {
             $solicitud->update(['estado' => Solicitud::EN_PROCESO]);
+            $this->whatsapp->queueOrdenEnProcesoNotification($solicitud, $user);
         }
 
         // Asegurar registros de pasos (ordenados por 'numero')

--- a/app/Jobs/SendOrdenEnProcesoWhatsapp.php
+++ b/app/Jobs/SendOrdenEnProcesoWhatsapp.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Solicitud;
+use App\Models\User;
+use App\Models\WhatsappNotification;
+use App\Services\WhatsappService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class SendOrdenEnProcesoWhatsapp implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public int $notificationId)
+    {
+    }
+
+    public function handle(WhatsappService $whatsapp): void
+    {
+        $notification = WhatsappNotification::find($this->notificationId);
+
+        if (!$notification || $notification->status !== WhatsappNotification::STATUS_PENDING) {
+            return;
+        }
+
+        $solicitud = Solicitud::with(['cliente', 'asignado'])->find($notification->solicitud_id);
+
+        if (!$solicitud) {
+            $notification->forceFill([
+                'status' => WhatsappNotification::STATUS_FAILED,
+                'error' => 'Solicitud no encontrada.',
+                'sent_at' => now(),
+            ])->save();
+
+            Log::warning('No se encontró la solicitud para enviar WhatsApp de orden en proceso.', [
+                'notification_id' => $notification->id,
+                'solicitud_id' => $notification->solicitud_id,
+            ]);
+
+            return;
+        }
+
+        $cliente = $solicitud->cliente;
+        $clienteNombre = $cliente?->nombre_cliente ?: ($cliente?->nombre ?? null);
+        $tipoServicio = $solicitud->tipo_servicio;
+        $empleadoNombre = $solicitud->asignado?->name;
+
+        if (!$empleadoNombre && $notification->actor_id) {
+            $empleadoNombre = User::find($notification->actor_id)?->name;
+        }
+
+        $fechaEntrega = $solicitud->fecha_vencimiento?->format('Y-m-d');
+        $telefonoNormalizado = $whatsapp->normalizeNumber($cliente?->telefono);
+
+        $faltantes = [];
+
+        if (!$whatsapp->isValidNumber($telefonoNormalizado)) {
+            $faltantes[] = 'telefono';
+        }
+
+        if (!$clienteNombre) {
+            $faltantes[] = 'cliente';
+        }
+
+        if (!$tipoServicio) {
+            $faltantes[] = 'servicio';
+        }
+
+        if (!$empleadoNombre) {
+            $faltantes[] = 'empleado';
+        }
+
+        if (!$fechaEntrega) {
+            $faltantes[] = 'fecha_entrega';
+        }
+
+        if ($faltantes !== []) {
+            $notification->forceFill([
+                'status' => WhatsappNotification::STATUS_SKIPPED,
+                'phone' => $telefonoNormalizado ?: null,
+                'error' => 'Datos incompletos: ' . implode(', ', $faltantes) . '.',
+                'sent_at' => now(),
+            ])->save();
+
+            Log::warning('No se envió WhatsApp de orden en proceso por datos incompletos.', [
+                'notification_id' => $notification->id,
+                'solicitud_id' => $solicitud->id,
+                'faltantes' => $faltantes,
+            ]);
+
+            return;
+        }
+
+        $parameters = [
+            (string) $clienteNombre,
+            (string) $tipoServicio,
+            (string) $empleadoNombre,
+            (string) $fechaEntrega,
+        ];
+
+        $notification->forceFill([
+            'phone' => $telefonoNormalizado,
+            'template_name' => 'mensaje',
+            'parameters' => $parameters,
+        ])->save();
+
+        $result = $whatsapp->sendOrdenEnProcesoTemplate($telefonoNormalizado, $parameters);
+        $ok = $result['ok'] ?? false;
+
+        $responseBody = $this->stringifyBody($result['body'] ?? null);
+
+        $notification->forceFill([
+            'status' => $ok ? WhatsappNotification::STATUS_SENT : WhatsappNotification::STATUS_FAILED,
+            'response' => $responseBody,
+            'error' => $ok ? null : $responseBody,
+            'sent_at' => now(),
+        ])->save();
+
+        if (!$ok) {
+            Log::warning('Fallo al enviar WhatsApp de orden en proceso.', [
+                'notification_id' => $notification->id,
+                'solicitud_id' => $solicitud->id,
+                'response' => $result['body'] ?? null,
+            ]);
+        }
+    }
+
+    private function stringifyBody(mixed $body): ?string
+    {
+        if (is_null($body)) {
+            return null;
+        }
+
+        if (is_string($body)) {
+            return $body;
+        }
+
+        $encoded = json_encode($body, JSON_UNESCAPED_UNICODE);
+
+        return $encoded === false ? null : $encoded;
+    }
+}

--- a/app/Models/WhatsappNotification.php
+++ b/app/Models/WhatsappNotification.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class WhatsappNotification extends Model
+{
+    public const EVENT_ORDEN_EN_PROCESO = 'orden_en_proceso';
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_SENT = 'sent';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_SKIPPED = 'skipped';
+
+    protected $fillable = [
+        'solicitud_id',
+        'actor_id',
+        'event_type',
+        'target_state',
+        'phone',
+        'template_name',
+        'parameters',
+        'status',
+        'response',
+        'error',
+        'sent_at',
+    ];
+
+    protected $casts = [
+        'parameters' => 'array',
+        'sent_at' => 'datetime',
+    ];
+
+    public function solicitud()
+    {
+        return $this->belongsTo(Solicitud::class);
+    }
+
+    public function actor()
+    {
+        return $this->belongsTo(User::class, 'actor_id');
+    }
+}

--- a/app/Services/WhatsappService.php
+++ b/app/Services/WhatsappService.php
@@ -2,7 +2,10 @@
 
 namespace App\Services;
 
+use App\Jobs\SendOrdenEnProcesoWhatsapp;
 use App\Models\Solicitud;
+use App\Models\User;
+use App\Models\WhatsappNotification;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -35,6 +38,16 @@ class WhatsappService
         }
 
         return $digits;
+    }
+
+    public function normalizeNumber(?string $tel): string
+    {
+        return $this->formatNumber((string) $tel);
+    }
+
+    public function isValidNumber(string $tel): bool
+    {
+        return $tel !== '' && str_starts_with($tel, '52') && ctype_digit($tel) && strlen($tel) >= 12;
     }
 
     protected function successfulStatus(?int $status): bool
@@ -121,6 +134,79 @@ class WhatsappService
             'status' => $response->status(),
             'body' => $body,
         ];
+    }
+
+    /**
+     * Send WhatsApp template for orden en proceso notification.
+     */
+    public function sendOrdenEnProcesoTemplate(string $telefono, array $parameters): array
+    {
+        $payload = [
+            'messaging_product' => 'whatsapp',
+            'to' => $telefono,
+            'type' => 'template',
+            'template' => [
+                'name' => 'mensaje',
+                'language' => ['code' => 'en'],
+                'components' => [
+                    [
+                        'type' => 'body',
+                        'parameters' => [
+                            ['type' => 'text', 'text' => (string) ($parameters[0] ?? '')],
+                            ['type' => 'text', 'text' => (string) ($parameters[1] ?? '')],
+                            ['type' => 'text', 'text' => (string) ($parameters[2] ?? '')],
+                            ['type' => 'text', 'text' => (string) ($parameters[3] ?? '')],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $response = Http::withToken(config('services.whatsapp.token'))
+            ->post($this->endpoint(), $payload);
+
+        $body = $response->json();
+        if (is_null($body)) {
+            $body = $response->body();
+        }
+
+        return [
+            'status' => $response->status(),
+            'body' => $body,
+            'ok' => $this->successfulStatus($response->status()),
+        ];
+    }
+
+    /**
+     * Queue WhatsApp notification for orden en proceso state.
+     */
+    public function queueOrdenEnProcesoNotification(Solicitud $solicitud, ?User $actor = null): ?WhatsappNotification
+    {
+        $notification = WhatsappNotification::firstOrCreate(
+            [
+                'solicitud_id' => $solicitud->id,
+                'event_type' => WhatsappNotification::EVENT_ORDEN_EN_PROCESO,
+                'target_state' => Solicitud::EN_PROCESO,
+            ],
+            [
+                'actor_id' => $actor?->id,
+                'template_name' => 'mensaje',
+                'status' => WhatsappNotification::STATUS_PENDING,
+            ]
+        );
+
+        if (!$notification->wasRecentlyCreated) {
+            Log::info('WhatsApp orden en proceso ya registrado; se omite el envío duplicado.', [
+                'notification_id' => $notification->id,
+                'solicitud_id' => $solicitud->id,
+            ]);
+
+            return null;
+        }
+
+        SendOrdenEnProcesoWhatsapp::dispatch($notification->id);
+
+        return $notification;
     }
 
     /**

--- a/database/migrations/2025_11_05_000000_create_whatsapp_notifications_table.php
+++ b/database/migrations/2025_11_05_000000_create_whatsapp_notifications_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('whatsapp_notifications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('solicitud_id')->constrained('solicitudes')->cascadeOnDelete();
+            $table->foreignId('actor_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('event_type', 50);
+            $table->string('target_state', 50)->nullable();
+            $table->string('phone', 25)->nullable();
+            $table->string('template_name', 100)->nullable();
+            $table->json('parameters')->nullable();
+            $table->string('status', 30)->default('pending');
+            $table->text('response')->nullable();
+            $table->text('error')->nullable();
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['solicitud_id', 'event_type', 'target_state'], 'whatsapp_notifications_event_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_notifications');
+    }
+};


### PR DESCRIPTION
Enviar un solo mensaje de plantilla de WhatsApp cuando una orden transiciona de pendiente a en_proceso (acción: Resolver / Iniciar atención) y asegurar que el cliente no reciba duplicados.

Proporcionar validación, trazabilidad y una UI no bloqueante reutilizando la integración existente de WhatsApp y ejecutando el envío en un job en cola con registros de auditoría.

Agregar una tabla whatsapp_notifications y el modelo App\Models\WhatsappNotification para registrar eventos, parámetros, teléfono destino, nombre de plantilla y el status de envío, con una restricción única en solicitud_id + event_type + target_state para garantizar idempotencia.

Implementar App\Jobs\SendOrdenEnProcesoWhatsapp, que valida los campos requeridos (teléfono, cliente, servicio, empleado, fecha), omite y registra los motivos cuando falten datos, envía la plantilla mensaje con idioma en y los cuatro parámetros en orden, y persiste respuesta/estado (pending|sent|failed|skipped).

Extender App\Services\WhatsappService con normalizeNumber, isValidNumber, sendOrdenEnProcesoTemplate (construye el payload template con 4 parámetros de body) y queueOrdenEnProcesoNotification, que crea el registro de notificación usando firstOrCreate y despacha el job para evitar envíos duplicados.

Conectar la transición del checklist en OrdenesServicioController::checklist para llamar a queueOrdenEnProcesoNotification($solicitud, $user) inmediatamente después de cambiar estado de pendiente a en_proceso, de forma que el envío quede encolado y sea no bloqueante.