### PR TITLE
Add client image upload with preview and responsive users mobile cards

### DIFF
--- a/app/Http/Controllers/ClientesCrudController.php
+++ b/app/Http/Controllers/ClientesCrudController.php
@@ -4,7 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Models\ClientesAsignacion;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class ClientesCrudController extends Controller
 {
@@ -37,6 +38,9 @@ class ClientesCrudController extends Controller
     public function store(Request $request)
     {
         $data = $this->validated($request);
+        if ($request->hasFile('imagen')) {
+            $data['imagen'] = $this->storeImage($request->file('imagen'));
+        }
         ClientesAsignacion::create($data);
         return redirect()->route('clientes.index')->with('ok', 'Cliente creado.');
     }
@@ -51,6 +55,12 @@ class ClientesCrudController extends Controller
     {
         $cliente = ClientesAsignacion::findOrFail($id);
         $data = $this->validated($request, $cliente->id);
+        if ($request->hasFile('imagen')) {
+            $data['imagen'] = $this->storeImage($request->file('imagen'));
+            $this->deleteImageIfLocal($cliente->imagen);
+        } else {
+            unset($data['imagen']);
+        }
         $cliente->update($data);
         return redirect()->route('clientes.index')->with('ok', 'Cliente actualizado.');
     }
@@ -71,8 +81,30 @@ class ClientesCrudController extends Controller
             'responsable'     => ['nullable','string','max:150'],
             'telefono'        => ['nullable','string','max:30'],
             'rfc'             => ['nullable','string','max:50'],
-            'imagen'          => ['nullable','string','max:255'],   // usa ruta/url; si quieres upload lo agregamos luego
+            'imagen'          => ['nullable','image','mimes:jpg,jpeg,png,webp','max:5120'],
             'correo_empresa'  => ['nullable','email','max:150'],
         ]);
+    }
+
+    private function storeImage($file): string
+    {
+        $filename = Str::uuid()->toString() . '.' . $file->getClientOriginalExtension();
+        $path = $file->storeAs('img_clientes', $filename, 'public');
+
+        return 'storage/' . $path;
+    }
+
+    private function deleteImageIfLocal(?string $path): void
+    {
+        if (!$path || filter_var($path, FILTER_VALIDATE_URL)) {
+            return;
+        }
+
+        $cleanPath = ltrim($path, '/');
+        if (str_starts_with($cleanPath, 'storage/')) {
+            $cleanPath = substr($cleanPath, strlen('storage/'));
+        }
+
+        Storage::disk('public')->delete($cleanPath);
     }
 }

--- a/resources/views/clientes/index.blade.php
+++ b/resources/views/clientes/index.blade.php
@@ -216,7 +216,7 @@
                     </button>
                 </div>
 
-                <form :action="formAction()" method="POST" class="grid gap-4 sm:grid-cols-2">
+                <form :action="formAction()" method="POST" enctype="multipart/form-data" class="grid gap-4 sm:grid-cols-2">
                     @csrf
                     <template x-if="mode==='edit'"><input type="hidden" name="_method" value="PUT"></template>
 
@@ -258,9 +258,37 @@
                                class="mt-1 w-full rounded-xl border-gray-300">
                     </div>
                     <div class="sm:col-span-2">
-                        <label class="text-sm text-gray-700">Imagen (ruta/url)</label>
-                        <input name="imagen" x-model="form.imagen" placeholder="storage/img_clientes/logo.png"
-                               class="mt-1 w-full rounded-xl border-gray-300">
+                        <label class="text-sm text-gray-700">Imagen del cliente</label>
+                        <div class="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center">
+                            <div class="flex items-center gap-3">
+                                <template x-if="newImageUrl">
+                                    <div class="flex items-center gap-3">
+                                        <img :src="newImageUrl" alt="Nueva imagen"
+                                             class="h-14 w-14 rounded-full object-cover ring-1 ring-gray-200">
+                                        <div class="text-xs text-gray-500">Nueva imagen</div>
+                                    </div>
+                                </template>
+                                <template x-if="!newImageUrl && existingImageUrl">
+                                    <div class="flex items-center gap-3">
+                                        <img :src="existingImageUrl" alt="Imagen actual"
+                                             class="h-14 w-14 rounded-full object-cover ring-1 ring-gray-200"
+                                             @error="existingImageUrl = null">
+                                        <div class="text-xs text-gray-500">Imagen actual</div>
+                                    </div>
+                                </template>
+                                <template x-if="!newImageUrl && !existingImageUrl">
+                                    <div class="h-14 w-14 rounded-full ring-1 ring-gray-200 flex items-center justify-center text-[10px] text-gray-500 bg-gray-100">
+                                        Sin imagen
+                                    </div>
+                                </template>
+                            </div>
+                            <div class="flex-1">
+                                <input type="file" name="imagen" accept="image/jpeg,image/png,image/webp"
+                                       x-ref="imagenInput" @change="handleImageChange($event)"
+                                       class="w-full rounded-xl border-gray-300 text-sm file:mr-4 file:rounded-lg file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-indigo-700 hover:file:bg-indigo-100">
+                                <p class="mt-1 text-xs text-gray-500">Formatos: JPG, PNG, WEBP (máx. 5 MB).</p>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="sm:col-span-2 mt-2 flex items-center justify-end gap-3">
@@ -286,17 +314,56 @@
             modalOpen:false,
             mode:'create',
             form:{ id:null,nombre_cliente:'',nombre_empresa:'',direccion:'',responsable:'',telefono:'',rfc:'',imagen:'',correo_empresa:'' },
-            openCreate(){ this.mode='create'; this.form={ id:null,nombre_cliente:'',nombre_empresa:'',direccion:'',responsable:'',telefono:'',rfc:'',imagen:'',correo_empresa:'' }; this.modalOpen=true; },
+            existingImageUrl:null,
+            newImageUrl:null,
+            openCreate(){
+                this.mode='create';
+                this.form={ id:null,nombre_cliente:'',nombre_empresa:'',direccion:'',responsable:'',telefono:'',rfc:'',imagen:'',correo_empresa:'' };
+                this.existingImageUrl=null;
+                this.clearImageInput();
+                this.modalOpen=true;
+            },
             openEdit(item){
                 this.mode='edit';
                 this.form={ id:item.id,nombre_cliente:item.nombre_cliente ?? '',nombre_empresa:item.nombre_empresa ?? '',direccion:item.direccion ?? '',responsable:item.responsable ?? '',telefono:item.telefono ?? '',rfc:item.rfc ?? '',imagen:item.imagen ?? '',correo_empresa:item.correo_empresa ?? '' };
+                this.existingImageUrl = this.resolveImageUrl(item.imagen);
+                this.clearImageInput();
                 this.modalOpen=true;
             },
-            close(){ this.modalOpen=false; },
+            close(){
+                this.modalOpen=false;
+                this.clearImageInput();
+            },
+            resolveImageUrl(path){
+                if(!path){ return null; }
+                if(/^https?:\/\//i.test(path)){ return path; }
+                return this.assetBase + path.replace(/^\/+/, '');
+            },
+            handleImageChange(event){
+                const file = event.target.files[0];
+                if(!file){
+                    this.newImageUrl = null;
+                    return;
+                }
+                if(this.newImageUrl){
+                    URL.revokeObjectURL(this.newImageUrl);
+                }
+                this.newImageUrl = URL.createObjectURL(file);
+            },
+            clearImageInput(){
+                if(this.newImageUrl){
+                    URL.revokeObjectURL(this.newImageUrl);
+                }
+                this.newImageUrl = null;
+                if(this.$refs?.imagenInput){
+                    this.$refs.imagenInput.value = '';
+                }
+            },
             formAction(){
                 if(this.mode==='create'){ return @json(route('clientes.store')); }
                 const base = @json(route('clientes.update','__ID__')); return base.replace('__ID__', this.form.id ?? '');
-            }
+            },
+            assetBase: @json(asset(''))
         }
     }
     </script>

--- a/resources/views/usuarios/index.blade.php
+++ b/resources/views/usuarios/index.blade.php
@@ -68,6 +68,12 @@
       .dataTables_paginate .paginate_button:hover{background:#F3F4F6}
       .dataTables_info{display:none}
 
+      @media (max-width: 767px) {
+        .card { border:0; background:transparent; box-shadow:none }
+        #tablaUsuarios { display:none }
+        .card .px-4 { padding-left:0; padding-right:0 }
+      }
+
       /* Modal: altura segura + scroll interno */
       .modal-card{ max-height: calc(100vh - 6rem); overflow:auto; }
       [x-cloak]{display:none !important;}
@@ -86,6 +92,8 @@
       @endif
     </div>
 
+    <div id="usuariosCards" class="md:hidden space-y-4"></div>
+
     <div class="card">
       <table id="tablaUsuarios" class="min-w-full text-sm">
         <thead>
@@ -100,7 +108,13 @@
         <tbody class="text-gray-700">
           @forelse ($usuarios as $usuario)
             @php($roles = $usuario->roles->pluck('name'))
-            <tr>
+            <tr data-user='@json([
+              "id" => $usuario->id,
+              "name" => $usuario->name,
+              "email" => $usuario->email,
+              "roles" => $roles->values(),
+              "created" => optional($usuario->created_at)->format("d/m/Y"),
+            ])'>
               <td class="font-medium text-gray-900">{{ $usuario->name }}</td>
               <td>{{ $usuario->email }}</td>
               <td>
@@ -327,6 +341,72 @@
           ]
         });
 
+        const escapeHtml = (value) => String(value ?? '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+
+        const renderCards = () => {
+          const $cards = $('#usuariosCards');
+          $cards.empty();
+
+          const totalCount = table.data().length;
+          const filteredCount = table.rows({ search: 'applied' }).count();
+          if (filteredCount === 0) {
+            const message = totalCount === 0 ? 'No hay usuarios registrados.' : 'No se encontraron resultados.';
+            $cards.append(`<div class="rounded-2xl border border-gray-200 bg-white p-6 text-center text-gray-500">${message}</div>`);
+            return;
+          }
+
+          table.rows({ page: 'current', search: 'applied' }).nodes().each((row) => {
+            const payload = JSON.parse(row.dataset.user || '{}');
+            const roles = Array.isArray(payload.roles) ? payload.roles : [];
+            const roleBadges = roles.length
+              ? roles.map((rol) => {
+                  const key = String(rol).toLowerCase();
+                  const klass = key === 'admin' ? 'role-admin' : (key === 'virtuality' ? 'role-virt' : '');
+                  const label = escapeHtml(String(rol).replace(/[_-]/g, ' '));
+                  return `<span class="role-badge ${klass}">${label}</span>`;
+                }).join('')
+              : '<span class="role-badge" style="background:#F3F4F6;color:#374151">Sin rol</span>';
+
+            const safeName = escapeHtml(payload.name ?? '');
+            const safeEmail = escapeHtml(payload.email ?? '');
+            const safeCreated = escapeHtml(payload.created || '—');
+            const safeRoles = JSON.stringify(roles);
+
+            $cards.append(`
+              <div class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+                <div class="flex items-start justify-between gap-3">
+                  <div class="min-w-0">
+                    <div class="font-semibold text-gray-900 truncate">${safeName}</div>
+                    <div class="text-sm text-gray-500 truncate">${safeEmail}</div>
+                    <div class="mt-2 flex flex-wrap gap-2">${roleBadges}</div>
+                    <div class="mt-2 text-xs text-gray-400">Creado: ${safeCreated}</div>
+                  </div>
+                  <div class="shrink-0">
+                    <button
+                      type="button"
+                      class="btn-edit inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs font-semibold text-gray-700 hover:bg-gray-50"
+                      data-id="${payload.id ?? ''}"
+                      data-name="${safeName}"
+                      data-email="${safeEmail}"
+                      data-roles='${safeRoles}'
+                    >
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                        <path d="M4 21h4l11-11a2.828 2.828 0 10-4-4L4 17v4z" stroke="currentColor" stroke-width="1.5"/>
+                      </svg>
+                      Editar
+                    </button>
+                  </div>
+                </div>
+              </div>
+            `);
+          });
+        };
+
         // Buscador externo
         $('#searchUsuarios').on('input', function(){ table.search(this.value).draw(); });
 
@@ -347,6 +427,9 @@
           $('#searchUsuarios').val(@json($q));
           table.search(@json($q)).draw();
         @endif
+
+        renderCards();
+        table.on('draw', renderCards);
       });
     </script>
   @endpush


### PR DESCRIPTION
Reemplazar el campo de texto “Imagen (ruta/url)” por una carga real de archivo, para que el usuario seleccione una imagen, se almacene en el servidor y se guarde su ruta en el registro del cliente.

Proveer una vista Usuarios compatible con móvil que use cards en pantallas pequeñas y mantenga la tabla en escritorio, conservando el comportamiento de búsqueda y paginación.

Descripción

Implementar el manejo de imágenes del lado del servidor en ClientesCrudController: validar tipo y tamaño con image|mimes:jpg,jpeg,png,webp|max:5120, almacenar archivos en public/img_clientes con nombre UUID mediante storeImage, y eliminar la imagen local anterior cuando sea reemplazada con deleteImageIfLocal (usando Storage y Str).

Actualizar la vista del modal de clientes resources/views/clientes/index.blade.php para usar enctype="multipart/form-data", reemplazar el input de texto por un input file, y agregar estado Alpine (existingImageUrl, newImageUrl) con manejo de preview y un resolvedor assetBase para que la imagen actual y la recién seleccionada se previsualicen correctamente sin cambiar el comportamiento cuando no se elige archivo.

Actualizar resources/views/usuarios/index.blade.php para renderizar una lista móvil #usuariosCards e inyectar HTML de cards generado a partir de payloads data-user por fila; las cards se sincronizan con la búsqueda y paginación de DataTables mediante renderCards() y table.on('draw', renderCards), escapando strings antes de insertarlas.

Agregar ajustes CSS responsivos para mostrar la tabla en desktop y las cards en móvil, manteniendo sin cambios los permisos existentes y las acciones de edición.